### PR TITLE
Update to rune-dsl 10.2.3 / bundle 12.3.3

### DIFF
--- a/.github/workflows/verify-readonly-namespaces.yml
+++ b/.github/workflows/verify-readonly-namespaces.yml
@@ -1,0 +1,18 @@
+name: Verify read-only namespaces
+
+# Fails when a pull request changes a read-only Rune namespace by hand.
+# For more info, see https://rune-docs.netlify.app/developers/read-only-namespaces
+
+on:
+  pull_request:
+    paths:
+      - "**/*.rosetta"
+      - "rosetta-source/src/main/resources/rune-config.yml"
+      - ".github/workflows/verify-readonly-namespaces.yml"
+
+jobs:
+  readonly-namespaces:
+    uses: finos/rune-dsl/.github/workflows/verify-readonly-namespaces.yml@main
+    with:
+      config-path: rosetta-source/src/main/resources/rune-config.yml
+      root: rosetta-source/src/main/rosetta

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>11</maven.compiler.release>
-        <rosetta.dsl.version>10.0.0-dev.12</rosetta.dsl.version>
-        <rosetta.bundle.version>12.0.0-dev.15</rosetta.bundle.version>
+        <rosetta.dsl.version>10.2.3</rosetta.dsl.version>
+        <rosetta.bundle.version>12.3.3</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>

--- a/rosetta-source/pom.xml
+++ b/rosetta-source/pom.xml
@@ -154,6 +154,7 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
+                            <runeConfig>${project.basedir}/src/main/resources/rune-config.yml</runeConfig>
                             <addOutputDirectoriesToCompileSourceRoots>false</addOutputDirectoriesToCompileSourceRoots>
                             <sourceRoots>
                                 <sourceRoot>${project.build.directory}/classes/fpml/rosetta</sourceRoot>

--- a/rosetta-source/src/main/resources/rune-config.yml
+++ b/rosetta-source/src/main/resources/rune-config.yml
@@ -1,0 +1,15 @@
+model:
+  name: FpML
+namespaceConfig:
+- id: fpml513Confirmation
+  namespace: fpml.consolidated
+  readOnly: true
+  schemaConfig:
+    schema: fpml513Confirmation
+    configPath: xml-config/fpml-5-13-confirmation-xml-config.json
+- id: fpml513Recordkeeping
+  namespace: fpml.consolidated
+  readOnly: true
+  schemaConfig:
+    schema: fpml513Recordkeeping
+    configPath: xml-config/fpml-5-13-recordkeeping-xml-config.json

--- a/rosetta-source/src/main/rosetta/consolidated-asset-type.rosetta
+++ b/rosetta-source/src/main/rosetta/consolidated-asset-type.rosetta
@@ -1713,7 +1713,7 @@ type UnderlyingAsset extends IdentifiedAsset:
             provision "Identification of the clearance system associated with the transaction exchange."]
         [docReference ISDA FPML version "confirmation-5.13"
             provision "Identification of the clearance system associated with the transaction exchange."]
-    ^definition ProductReference (0..1)
+    definition ProductReference (0..1)
         [docReference ISDA FPML version "recordkeeping-5.13"
             provision "An optional reference to a full FpML product that defines the simple product in greater detail. In case of inconsistency between the terms of the simple product and those of the detailed definition, the values in the simple product override those in the detailed definition."]
         [docReference ISDA FPML version "confirmation-5.13"

--- a/rosetta-source/src/main/rosetta/consolidated-desc.rosetta
+++ b/rosetta-source/src/main/rosetta/consolidated-desc.rosetta
@@ -6,3 +6,9 @@ body Source ISDA
 corpus Schema "FPML" FPML
 
 segment version
+
+schema fpml513Recordkeeping XML
+    [externalConfig]
+
+schema fpml513Confirmation XML
+    [externalConfig]

--- a/rosetta-source/src/main/rosetta/consolidated-mktenv-type.rosetta
+++ b/rosetta-source/src/main/rosetta/consolidated-mktenv-type.rosetta
@@ -530,7 +530,7 @@ type TermPoint:
             provision "The spread value can be used in conjunction with the \"mid\" value to define the bid and the ask value."]
         [docReference ISDA FPML version "confirmation-5.13"
             provision "The spread value can be used in conjunction with the \"mid\" value to define the bid and the ask value."]
-    ^definition AssetReference (0..1)
+    definition AssetReference (0..1)
         [docReference ISDA FPML version "recordkeeping-5.13"
             provision "An optional reference to an underlying asset that defines the meaning of the value, i.e. the product that the value corresponds to. For example, this could be a discount instrument."]
         [docReference ISDA FPML version "confirmation-5.13"

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex19-cds-execution-allocations.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex19-cds-execution-allocations.xml
@@ -11,15 +11,15 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">10000</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">10000</tradeId>
         <allocationTradeId>
-          <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">10001</tradeId>
           <partyReference href="party3"/>
+          <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">10001</tradeId>
         </allocationTradeId>
         <allocationTradeId>
-          <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">10002</tradeId>
           <partyReference href="party3"/>
+          <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">10002</tradeId>
         </allocationTradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex54-execution-advice-trade-partial-termination-C11-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex54-execution-advice-trade-partial-termination-C11-00.xml
@@ -11,11 +11,11 @@
   <sequenceNumber>3</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>27</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </tradeIdentifier>
     <agreementDate>2009-07-22T00:00:00</agreementDate>
     <effectiveDate>2009-07-23T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex55-execution-advice-trade-partial-termination-cancellation-C11-10.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex55-execution-advice-trade-partial-termination-cancellation-C11-10.xml
@@ -10,11 +10,11 @@
   <sequenceNumber>4</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>27</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </tradeIdentifier>
     <agreementDate>2009-07-22T00:00:00</agreementDate>
     <effectiveDate>2009-07-23T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex56-execution-advice-trade-full-termination-C12-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex56-execution-advice-trade-full-termination-C12-00.xml
@@ -11,11 +11,11 @@
   <sequenceNumber>1</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>30</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </tradeIdentifier>
     <agreementDate>2009-07-24T00:00:00</agreementDate>
     <effectiveDate>2009-07-27T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex57-execution-advice-trade-full-termination_correction-C12-20.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex57-execution-advice-trade-full-termination_correction-C12-20.xml
@@ -11,11 +11,11 @@
   <sequenceNumber>3</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>32</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </tradeIdentifier>
     <agreementDate>2009-07-24T00:00:00</agreementDate>
     <effectiveDate>2009-07-27T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex59-execution-advice-trade-amendment-F02-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex59-execution-advice-trade-amendment-F02-00.xml
@@ -13,11 +13,11 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR3456</tradeId>
             <version>2</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-09-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex60-execution-advice-trade-amendment-correction-F02-10.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex60-execution-advice-trade-amendment-correction-F02-10.xml
@@ -13,11 +13,11 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR3456</tradeId>
             <version>2</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-09-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex61-execution-advice-trade-change-F03-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex61-execution-advice-trade-change-F03-00.xml
@@ -13,11 +13,11 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR3456</tradeId>
             <version>2</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-09-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex62-execution-advice-trade-change-correction-F03-10.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex62-execution-advice-trade-change-correction-F03-10.xml
@@ -13,11 +13,11 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR3456</tradeId>
             <version>2</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-09-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex64-execution-advice-trade-initiation-correction.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex64-execution-advice-trade-initiation-correction.xml
@@ -12,11 +12,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="SKY"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">IRS2</tradeId>
           <version>2</version>
         </versionedTradeId>
-        <partyReference href="SKY"/>
       </partyTradeIdentifier>
       <tradeDate>2007-07-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex65-execution-advice-trade-partial-termination.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex65-execution-advice-trade-partial-termination.xml
@@ -12,12 +12,12 @@
   <sequenceNumber>1</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="SKY"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">IRS2</tradeId>
         <version>3</version>
         <effectiveDate>2008-07-30T00:00:00</effectiveDate>
       </versionedTradeId>
-      <partyReference href="SKY"/>
     </tradeIdentifier>
     <agreementDate>2008-07-25T00:00:00</agreementDate>
     <effectiveDate>2008-07-30T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex66-execution-advice-trade-full-termination.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex66-execution-advice-trade-full-termination.xml
@@ -12,12 +12,12 @@
   <sequenceNumber>4</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="SKY"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">IRS2</tradeId>
         <version>4</version>
         <effectiveDate>2008-07-30T00:00:00</effectiveDate>
       </versionedTradeId>
-      <partyReference href="SKY"/>
     </tradeIdentifier>
     <agreementDate>2008-07-26T00:00:00</agreementDate>
     <effectiveDate>2009-07-30T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex67-execution-advice-trade-full-termination-correction.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/msg-ex67-execution-advice-trade-full-termination-correction.xml
@@ -12,12 +12,12 @@
   <sequenceNumber>5</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="SKY"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">IRS2</tradeId>
         <version>5</version>
         <effectiveDate>2008-07-30T00:00:00</effectiveDate>
       </versionedTradeId>
-      <partyReference href="SKY"/>
     </tradeIdentifier>
     <agreementDate>2008-07-26T00:00:00</agreementDate>
     <effectiveDate>2009-07-30T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/pkg-ex01-pkge-execution-notification.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/pkg-ex01-pkge-execution-notification.xml
@@ -19,8 +19,8 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
-          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
           <partyReference href="sef"/>
+          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
         </partyTradeIdentifier>
         <tradeDate>2014-01-15T00:00:00</tradeDate>
       </tradeHeader>
@@ -167,8 +167,8 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
-          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">2</tradeId>
           <partyReference href="sef"/>
+          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">2</tradeId>
         </partyTradeIdentifier>
         <tradeDate>2014-01-15T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
         <partyReference href="sef"/>
+        <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
       </partyTradeIdentifier>
       <originatingPackage>
         <packageIdentifier>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/pkg-ex55-execution-notification.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/pkg-ex55-execution-notification.xml
@@ -19,8 +19,8 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
-          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
           <partyReference href="sef"/>
+          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
         </partyTradeIdentifier>
         <tradeDate>2014-01-15T00:00:00</tradeDate>
       </tradeHeader>
@@ -167,8 +167,8 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
-          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">2</tradeId>
           <partyReference href="sef"/>
+          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">2</tradeId>
         </partyTradeIdentifier>
         <tradeDate>2014-01-15T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/pkg-ex60-request-clearing.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/pkg-ex60-request-clearing.xml
@@ -27,8 +27,8 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
-          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
           <partyReference href="sef"/>
+          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
         </partyTradeIdentifier>
         <tradeDate>2014-01-15T00:00:00</tradeDate>
       </tradeHeader>
@@ -177,8 +177,8 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
-          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">2</tradeId>
           <partyReference href="sef"/>
+          <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">2</tradeId>
         </partyTradeIdentifier>
         <tradeDate>2014-01-15T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/pkg-ex61-clearing-confirmed.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-processes/pkg-ex61-clearing-confirmed.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
         <partyReference href="sef"/>
+        <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
       </partyTradeIdentifier>
       <originatingPackage>
         <packageIdentifier>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/bond-options/bond-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/bond-options/bond-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-05-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/bond-options/cb-option-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/bond-options/cb-option-2.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Bond1</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Bond1</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-12-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/bond-options/cb-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/bond-options/cb-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-01-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex10-physical-oil-pipeline-crude-wti-floating-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex10-physical-oil-pipeline-crude-wti-floating-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex11-physical-oil-pipeline-heating-oil-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex11-physical-oil-pipeline-heating-oil-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex12-physical-gas-europe-zbt-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex12-physical-gas-europe-zbt-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex13-physical-gas-us-tw-west-texas-pool-floating-price-4-days.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex13-physical-gas-us-tw-west-texas-pool-floating-price-4-days.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex14-physical-gas-europe-ttf-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex14-physical-gas-europe-ttf-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex15-physical-oil-pipeline-crude-wcs-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex15-physical-oil-pipeline-crude-wcs-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex16-physical-power-us-eei-floating-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex16-physical-power-us-eei-floating-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex17-physical-power-uk-gtma-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex17-physical-power-uk-gtma-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex18-physical-power-us-eei-fixed-price-shaped-volume.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex18-physical-power-us-eei-fixed-price-shaped-volume.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-04-22T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex19-physical-bullion-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex19-physical-bullion-forward.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex20-physical-coal-us-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex20-physical-coal-us-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex21-physical-power-us-eei-fixed-price-shaped-volume-and-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex21-physical-power-us-eei-fixed-price-shaped-volume-and-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-04-22T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex22-physical-gas-option-multiple-expiration.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex22-physical-gas-option-multiple-expiration.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-04-22T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex23-physical-power-option-daily-expiration-efet.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex23-physical-power-option-daily-expiration-efet.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">268151</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">268151</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">268151</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">268151</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex24-weather-index-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex24-weather-index-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-05-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex25-physical-bullion-forward-average-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex25-physical-bullion-forward-average-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.techco.com/com-trade-id">TechCo1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.techco.com/com-trade-id">TechCo1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.banka.com/com-trade-id">BankA5678</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.banka.com/com-trade-id">BankA5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-03-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex26-physical-metal-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex26-physical-metal-forward.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.BankA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.BankA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.BankB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.BankB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2013-03-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex29-physical-eu-emissions-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex29-physical-eu-emissions-option.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="tradeDate">2012-06-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex30-physical-eu-emissions-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex30-physical-eu-emissions-forward.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="tradeDate">2012-06-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex31-physical-us-emissions-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex31-physical-us-emissions-option.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="tradeDate">2012-06-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex32-CPD-weather-index-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex32-CPD-weather-index-option.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-04-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex33-physical-bullion-forward-average-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex33-physical-bullion-forward-average-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.techco.com/com-trade-id">TechCo1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.techco.com/com-trade-id">TechCo1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.banka.com/com-trade-id">BankA5678</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.banka.com/com-trade-id">BankA5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-03-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex34-gas-put-option-european-floating-strike.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex34-gas-put-option-european-floating-strike.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyA.com/spec/2001/trade-id-1-0">COA1234567</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.companyA.com/spec/2001/trade-id-1-0">COA1234567</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyB.com/spec/2001/trade-id-1-0">COB7654321</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.companyB.com/spec/2001/trade-id-1-0">COB7654321</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-04-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex35-call-option-gas-power-heat-rate-daily.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex35-call-option-gas-power-heat-rate-daily.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyA.com/spec/2001/trade-id-1-0">163476</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.companyA.com/spec/2001/trade-id-1-0">163476</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyB.com/spec/2001/trade-id-1-0">163476</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.companyB.com/spec/2001/trade-id-1-0">163476</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-04-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex36-gas-call-option-european-spread-negative-premium-floating-strike.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex36-gas-call-option-european-spread-negative-premium-floating-strike.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyA.com/spec/2012/trade-id-1-0">COA24680</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.companyA.com/spec/2012/trade-id-1-0">COA24680</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyB.com/spec/2012/trade-id-1-0">COB13579</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.companyB.com/spec/2012/trade-id-1-0">COB13579</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-06-06T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex37-gold-forward-offered-rate.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex37-gold-forward-offered-rate.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.bankB.com/swaps/com-trade-id">BankA1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.bankB.com/swaps/com-trade-id">BankA1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.bankA.com/swaps/com-trade-id">BankB5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.bankA.com/swaps/com-trade-id">BankB5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-01-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex40-gas-digital-option-storage-volume-trigger.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex40-gas-digital-option-storage-volume-trigger.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ABCD1234</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ABCD1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2013-05-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex42-index-return-swap-reinvestment-feature.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex42-index-return-swap-reinvestment-feature.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">SUSNUMERIS</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">SUSNUMERIS</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2014-01-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex43-WTI-variance-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex43-WTI-variance-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">T901234-123456</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">T901234-123456</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2012-05-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex44-index-return-swap-fixed-notional.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex44-index-return-swap-fixed-notional.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ACIRST1234567</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ACIRST1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2014-04-08T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex45-ag-variance-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex45-ag-variance-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ACAVS1234567</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ACAVS1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2014-04-08T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex47-physical-eu-emissions-option-pred-clearing.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/commodity-derivatives/com-ex47-physical-eu-emissions-option-pred-clearing.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="tradeDate">2012-06-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex01-long-asia-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex01-long-asia-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex02-2003-short-asia-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex02-2003-short-asia-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex02-short-asia-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex02-short-asia-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex03-long-aussie-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex03-long-aussie-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37258</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37258</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37258</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37258</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex04-short-aussie-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex04-short-aussie-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex05-long-emasia-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex05-long-emasia-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37260</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37260</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37260</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37260</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-08-22T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex06-long-emeur-sov-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex06-long-emeur-sov-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37261</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37261</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37261</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37261</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-07-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex07-2003-long-euro-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex07-2003-long-euro-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex07-long-euro-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex07-long-euro-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex08-2003-short-euro-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex08-2003-short-euro-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex08-short-euro-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex08-short-euro-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex09-long-euro-sov-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex09-long-euro-sov-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37263</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37263</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37263</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37263</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-11-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex10-2003-long-us-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex10-2003-long-us-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex10-long-us-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex10-long-us-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex11-2003-short-us-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex11-2003-short-us-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex11-short-us-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex11-short-us-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex12-long-emasia-sov-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex12-long-emasia-sov-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex13-long-asia-sov-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex13-long-asia-sov-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37206</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37206</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37206</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37206</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-11-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex14-long-emlatin-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex14-long-emlatin-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37203</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37203</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37203</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37203</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-08-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex15-long-emlatin-sov-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex15-long-emlatin-sov-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37204</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37204</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37204</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37204</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-11-22T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex16-short-us-corp-fixreg-recovery-factor.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex16-short-us-corp-fixreg-recovery-factor.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex17-short-us-corp-portfolio-compression.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex17-short-us-corp-portfolio-compression.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex18-standard-north-american-corp.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex18-standard-north-american-corp.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-03-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex19-cdx-index-option-pred-clearing.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-ex19-cdx-index-option-pred-clearing.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-01-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-indamt-ex01-short-us-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-indamt-ex01-short-us-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-swaption-1.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-swaption-1.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade123</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade123</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-12-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-swaption-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cd-swaption-2.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-06-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdindex-ex01-cdx.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdindex-ex01-cdx.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdindex-ex02-iTraxx.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdindex-ex02-iTraxx.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-11-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdindex-ex03-iTraxx-contractual-supplement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdindex-ex03-iTraxx-contractual-supplement.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">ITRAXX1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">ITRAXX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">1234B6</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">1234B6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-11-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdindex-ex04-iBoxx.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdindex-ex04-iBoxx.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdindex-ex05-SP.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdindex-ex05-SP.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-ELCDS-ReferenceObligation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-ELCDS-ReferenceObligation.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
         <partyReference href="DTCCPty1"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2007-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-basket-tranche.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-basket-tranche.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <linkId linkIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/linkID">USDINDEX</linkId>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-basket.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <linkId linkIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/linkID">USDINDEX</linkId>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-custom-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-custom-basket.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <linkId id="lid1" linkIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/linkID">USDINDEX</linkId>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-index-tranche.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-index-tranche.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-11-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-loan-ReferenceObligation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-loan-ReferenceObligation.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-10-26T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-loan-SecuredList.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-loan-SecuredList.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-12-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-mortgage-CMBS.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-mortgage-CMBS.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-11-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-mortgage-RMBS.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cds-mortgage-RMBS.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-10-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdx-index-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/cdx-index-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-01-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/itraxx-index-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/credit-derivatives/itraxx-index-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-01-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex01-american-call-stock-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex01-american-call-stock-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex02-calendar-spread-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex02-calendar-spread-short-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/tradeId/OTC">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/tradeId/OTC">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex03-call-or-put-spread-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex03-call-or-put-spread-short-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/tradeId/OTC">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/tradeId/OTC">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex04-european-call-index-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex04-european-call-index-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-09-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex05-asian-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex05-asian-long-form.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex06-averaging-in-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex06-averaging-in-long-form.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex07-barrier-knockout-rebate-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex07-barrier-knockout-rebate-long-form.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-07-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex08-basket-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex08-basket-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex09-bermuda-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex09-bermuda-long-form.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">LN 2962</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">LN 2962</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex10-binary-barrier-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex10-binary-barrier-long-form.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-03-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex11-quanto-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex11-quanto-long-form.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex12-vanilla-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex12-vanilla-short-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/tradeId/OTC">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/tradeId/OTC">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex13-1996-american-call-stock.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex13-1996-american-call-stock.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex14-american-call-stock-passthrough-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex14-american-call-stock-passthrough-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex15-basket-passthrough-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex15-basket-passthrough-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex16-equityOptionTransactionSupplement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex16-equityOptionTransactionSupplement.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/tradeId/OTC">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/tradeId/OTC">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2005-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex17-equityOptionTransactionSupplement-non-deliverable-share.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex17-equityOptionTransactionSupplement-non-deliverable-share.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">1</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">1</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">1</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">1</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-09-18T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex18-equityOptionTransactionSupplement-non-deliverable-index.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex18-equityOptionTransactionSupplement-non-deliverable-index.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">2</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">2</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">2</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">2</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-02-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex19-dividend-adjustment.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex19-dividend-adjustment.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="jb2890"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2006-08-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex20-nested-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex20-nested-basket.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex21-flat-weight-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex21-flat-weight-basket.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex22-equityOptionTransactionSupplement-index-option-asian-dates.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex22-equityOptionTransactionSupplement-index-option-asian-dates.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex23-equityOptionTransactionSupplement-index-option-cliquet.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex23-equityOptionTransactionSupplement-index-option-cliquet.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex24-equityOptionTransactionSupplement-index-option-asian-schedule.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex24-equityOptionTransactionSupplement-index-option-asian-schedule.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex25-equityOptionTransactionSupplement-index-option-knock-in-knock-out-features.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex25-equityOptionTransactionSupplement-index-option-knock-in-knock-out-features.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex26-mixed-asset-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex26-mixed-asset-basket.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex27-equityOptionTransactionSupplement-EMEA-interdealer.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-options/eqd-ex27-equityOptionTransactionSupplement-EMEA-interdealer.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">2783639</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">2783639</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">2783639</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">2783639</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-02-11T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex03-index-quanto-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex03-index-quanto-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex04-zero-strike-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex04-zero-strike-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-10-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex05-single-stock-plus-fee-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex05-single-stock-plus-fee-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1934</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1934</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5978</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5978</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-09-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex07-long-form-with-stub.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex07-long-form-with-stub.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://http://www.partyB.com/eqs-trade-id">5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://http://www.partyB.com/eqs-trade-id">5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex08-composite-basket-long-form-separate-spreads.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex08-composite-basket-long-form-separate-spreads.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1245</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1245</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">4569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">4569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex15-forward-starting-pre-european-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex15-forward-starting-pre-european-interdealer-share-swap-short-form.xml
@@ -12,18 +12,18 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">8848551</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>2009-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.xml
@@ -12,18 +12,18 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
           <version>2</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">8848551</tradeId>
           <version>2</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>2009-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex17-cfd.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex17-cfd.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.primarybank.com/trade-id">CFD123456789</tradeId>
         <partyReference href="PRIMARY"/>
+        <tradeId tradeIdScheme="http://www.primarybank.com/trade-id">CFD123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.crossbank.com/tradeId">CFD123456789</tradeId>
         <partyReference href="CROSS"/>
+        <tradeId tradeIdScheme="http://www.crossbank.com/tradeId">CFD123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate__CFD123456789">2009-09-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex18-pan-asia-interdealer-index-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex18-pan-asia-interdealer-index-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-09-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-09-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/trs-ex01-equity-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/trs-ex01-equity-basket.xml
@@ -3,12 +3,12 @@
   <trade id="trs-eqbasket-trade">
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-02</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-02</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-02</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-02</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="r13">2004-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/trs-ex02-single-equity.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/trs-ex02-single-equity.xml
@@ -3,12 +3,12 @@
   <trade id="trs-eq1-trade">
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="trs-eq1-TradeDate">2004-10-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/trs-ex04-index-ios.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/equity-swaps/trs-ex04-index-ios.xml
@@ -3,12 +3,12 @@
   <trade id="trs-ex4-trade">
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-03-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/dcd-ex01-dual-currency-deposit.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/dcd-ex01-dual-currency-deposit.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.midlandnb.com/swaps/trade-id">MB87623</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.midlandnb.com/swaps/trade-id">MB87623</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn.com/swaps/trade-id">AA9876</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abn.com/swaps/trade-id">AA9876</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-06-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex13-fx-dbl-barrier-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex13-fx-dbl-barrier-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex14-euro-digital-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex14-euro-digital-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10014</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10014</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20014</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20014</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex15-euro-range-digital-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex15-euro-range-digital-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10015</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10015</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20015</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20015</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex16-one-touch-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex16-one-touch-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10016</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10016</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20016</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20016</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex17-no-touch-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex17-no-touch-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10017</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10017</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20018</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20018</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex18-double-one-touch-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex18-double-one-touch-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10018</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10018</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20018</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20018</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex19-double-no-touch-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex19-double-no-touch-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10019</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10019</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20019</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20019</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex21-avg-rate-option-parametric-plus-rate-observation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex21-avg-rate-option-parametric-plus-rate-observation.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.chase.com/fx/trade-id">CH-23948</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.chase.com/fx/trade-id">CH-23948</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-89080</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-89080</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-08-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex23-straddle.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex23-straddle.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex24-delta-hedge.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex24-delta-hedge.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex25-option-strategyComponentIdentifier.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex25-option-strategyComponentIdentifier.xml
@@ -28,12 +28,12 @@
         <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/unique-transaction-identifier">01234567890123456789012345678914</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex26-fxswap-multiple-USIs.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex26-fxswap-multiple-USIs.xml
@@ -20,12 +20,12 @@
         <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/unique-transaction-identifier">712345678901234567890123456789013</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex27-flexible-term-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex27-flexible-term-forward.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.bnpparibas.com/trade-id">87654321</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.bnpparibas.com/trade-id">87654321</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-09-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex30-variance-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex30-variance-swap.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2011-03-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex31-volatility-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex31-volatility-swap.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2011-03-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex32-forward-volatility-agreement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex32-forward-volatility-agreement.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2014-09-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex33-target.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex33-target.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abc.com/trade-id">12345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abc.com/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-09-11T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex34-target-digital.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex34-target-digital.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-06-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex35-target-pivot-settlement-period-schedule.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex35-target-pivot-settlement-period-schedule.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-07-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex35-target-pivot.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex35-target-pivot.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-07-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex36-target-leverage.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex36-target-leverage.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-11-07T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex37-target-knockout.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex37-target-knockout.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-11-07T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex38-target-rebate.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex38-target-rebate.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-02-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex39-target-split.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex39-target-split.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-12-21T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex40-target-accelerated.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex40-target-accelerated.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-12-21T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex41-target-bonus-collar-settlement-period-schedule.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex41-target-bonus-collar-settlement-period-schedule.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-07-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex41-target-bonus-collar.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex41-target-bonus-collar.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-07-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex42-target-eki.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex42-target-eki.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-07-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex43-target-eki-settlement-period-schedule-references.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex43-target-eki-settlement-period-schedule-references.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-07-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex43-target-eki-settlement-period-schedule.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex43-target-eki-settlement-period-schedule.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-07-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex43-target-eki.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex43-target-eki.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
         <partyReference href="ptyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-07-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex44-accrual-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex44-accrual-forward.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-03-26T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex45-accrual-forward-leverage.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex45-accrual-forward-leverage.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-06-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex46-accrual-forward-american-lose-boost.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex46-accrual-forward-american-lose-boost.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-12-08T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex47-accrual-forward-european-fading-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex47-accrual-forward-european-fading-forward.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-01-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex48-accrual-option-strategy-fading-extra.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex48-accrual-option-strategy-fading-extra.xml
@@ -10,12 +10,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-10-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex49-accrual-forward-boost-strip-settlement-period-schedule.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex49-accrual-forward-boost-strip-settlement-period-schedule.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-10-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex49-accrual-forward-boost-strip.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex49-accrual-forward-boost-strip.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-10-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex50-accrual-forward-double-accrual.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex50-accrual-forward-double-accrual.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-01-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex51-accrual-forward-american-keep-double-multi-settlement-settlement-period-schedule.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex51-accrual-forward-american-keep-double-multi-settlement-settlement-period-schedule.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-07-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex51-accrual-forward-american-keep-double-multi-settlement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex51-accrual-forward-american-keep-double-multi-settlement.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-07-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex52-accrual-forward-collar.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex52-accrual-forward-collar.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-01-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex53-accrual-forward-variable-strike.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex53-accrual-forward-variable-strike.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-07-07T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex54-accrual-option-american.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex54-accrual-option-american.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-06-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex55-accrual-option-average-strike.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex55-accrual-option-average-strike.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-10-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex56-accrual-option-average-rate.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex56-accrual-option-average-rate.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-01-11T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex57-accrual-digital-option-american.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex57-accrual-digital-option-american.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-06-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex58-accrual-range-accrual-european.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex58-accrual-range-accrual-european.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-03-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex59-accrual-range-accrual-european.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/fx-ex59-accrual-range-accrual-european.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="#partyA">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="#partyA">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-12-08T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/td-ex01-simple-term-deposit.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/td-ex01-simple-term-deposit.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hsbc.com/swaps/trade-id">MB87623</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.hsbc.com/swaps/trade-id">MB87623</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abnamro.com/swaps/trade-id">AA9876</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abnamro.com/swaps/trade-id">AA9876</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-02-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/td-ex02-term-deposit-w-settlement-etc.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/fx-derivatives/td-ex02-term-deposit-w-settlement-etc.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.midlandnb.com/swaps/trade-id">MB87623</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.midlandnb.com/swaps/trade-id">MB87623</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn.com/swaps/trade-id">AA9876</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abn.com/swaps/trade-id">AA9876</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-02-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/inflation-swaps/v1_inflation-asset-swap-ex03-par-par.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/inflation-swaps/v1_inflation-asset-swap-ex03-par-par.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/trade-package-id">TR2</tradeId>
         <partyReference href="tradeSource"/>
+        <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/trade-package-id">TR2</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="counterpartyA"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/inflation-swaps/v2_inflation-asset-swap-ex03-par-par.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/inflation-swaps/v2_inflation-asset-swap-ex03-par-par.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/trade-package-id">TR2</tradeId>
         <partyReference href="tradeSource"/>
+        <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/trade-package-id">TR2</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="counterpartyA"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/securities/sec-ex001-trade-execution-future.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/securities/sec-ex001-trade-execution-future.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2012-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/securities/sec-ex002-trade-execution-exchange-traded-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/incomplete-products/securities/sec-ex002-trade-execution-exchange-traded-option.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2012-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/AdditionalFixedPayments_mortgages.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/AdditionalFixedPayments_mortgages.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="yt67d"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="yt67d"/>
       </partyTradeIdentifier>
       <tradeDate>2006-10-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/BasketReferenceInformation_nameOrId.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/BasketReferenceInformation_nameOrId.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fyure4"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fyure4"/>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/BasketReferenceInformation_nthToDefault_mthToDefault.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/BasketReferenceInformation_nthToDefault_mthToDefault.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fyure4"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fyure4"/>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/CalculationPeriodDates_firstCompoundingPeriodEndDate.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/CalculationPeriodDates_firstCompoundingPeriodEndDate.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">LCH00023444650</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2018-01-26T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/CalculationPeriod_choice4.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/CalculationPeriod_choice4.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/CreditEvents_mortgages.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/CreditEvents_mortgages.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="yt67d"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="yt67d"/>
       </partyTradeIdentifier>
       <tradeDate>2006-10-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/CreditEvents_physicalSettlementMatrix-1.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/CreditEvents_physicalSettlementMatrix-1.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fg4rde3"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fg4rde3"/>
       </partyTradeIdentifier>
       <tradeDate>2006-12-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/CreditEvents_physicalSettlementMatrix-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/CreditEvents_physicalSettlementMatrix-2.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fg4rde3"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fg4rde3"/>
       </partyTradeIdentifier>
       <tradeDate>2006-12-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/DeliverableObligations_physicalSettlementMatrix-1.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/DeliverableObligations_physicalSettlementMatrix-1.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fg4rde3"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fg4rde3"/>
       </partyTradeIdentifier>
       <tradeDate>2006-12-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/DeliverableObligations_physicalSettlementMatrix-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/DeliverableObligations_physicalSettlementMatrix-2.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fg4rde3"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fg4rde3"/>
       </partyTradeIdentifier>
       <tradeDate>2006-12-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FloatingAmountEvents_mortgages.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FloatingAmountEvents_mortgages.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="yt67d"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="yt67d"/>
       </partyTradeIdentifier>
       <tradeDate>2006-10-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_12.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_12.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37263</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-11-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_19.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_19.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_26_28.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_26_28.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_27-1.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_27-1.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_27-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_27-2.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_27-3.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_27-3.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_30-1.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_30-1.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_30-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_30-2.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_34.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_34.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fg4rde3"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fg4rde3"/>
       </partyTradeIdentifier>
       <tradeDate>2006-12-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_37.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_37.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fyure4"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fyure4"/>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_41.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_41.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_42.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_42.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_44.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_cd_44.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID" id="tid1">DJITRAXXUSDMS5Y</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_14.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_14.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_21_economicTermsEffectiveDate.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_21_economicTermsEffectiveDate.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37263</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-11-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_21_payoutEffectiveDate.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_21_payoutEffectiveDate.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_29.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_29.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2000-04-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_29_FpML_ird_9.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_29_FpML_ird_9.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2000-04-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_30.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_30.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_35_cd_31-1.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_35_cd_31-1.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37206</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-11-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_35_cd_31-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_35_cd_31-2.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37206</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-11-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_35_cd_31.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_35_cd_31.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.bankA.com/swaps/trade-id">TW9235</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_6.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_6.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.bankA.com/swaps/trade-id">TW9235</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_7_1.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_7_1.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2000-04-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_7_2-distinct-within-the-leg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_7_2-distinct-within-the-leg.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2000-04-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_8.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_8.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_9_ResetDates_interestRateSwap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/FpML_ird_9_ResetDates_interestRateSwap.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2000-04-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/Obligations_physicalSettlementMatrix-1.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/Obligations_physicalSettlementMatrix-1.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fg4rde3"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fg4rde3"/>
       </partyTradeIdentifier>
       <tradeDate>2006-12-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/Obligations_physicalSettlementMatrix-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/Obligations_physicalSettlementMatrix-2.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fg4rde3"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fg4rde3"/>
       </partyTradeIdentifier>
       <tradeDate>2006-12-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/PaymentDates_paymentDaysOffset.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/PaymentDates_paymentDaysOffset.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.bankA.com/swaps/trade-id">TW9235</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/Tranche_dataRules.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/invalid-products/Tranche_dataRules.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fyure4"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fyure4"/>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-ex51-execution-advice-trade-initiation-C01-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-ex51-execution-advice-trade-initiation-C01-00.xml
@@ -12,11 +12,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="_fund"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="_fund"/>
       </partyTradeIdentifier>
       <tradeDate>2009-06-08T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-ex52-execution-advice-trade-partial-novation-C02-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-ex52-execution-advice-trade-partial-novation-C02-00.xml
@@ -11,20 +11,20 @@
   <sequenceNumber>2</sequenceNumber>
   <novation>
     <newTradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>2</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </newTradeIdentifier>
     <oldTrade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
             <version>1</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-06-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.xml
@@ -11,20 +11,20 @@
   <sequenceNumber>3</sequenceNumber>
   <novation>
     <newTradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>3</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </newTradeIdentifier>
     <oldTrade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
             <version>1</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-06-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-ex58-execution-advice-trade-initiation-F01-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-ex58-execution-advice-trade-initiation-F01-00.xml
@@ -12,11 +12,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="_fund"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR3456</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="_fund"/>
       </partyTradeIdentifier>
       <tradeDate>2009-09-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-ex63-execution-advice-trade-initiation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-ex63-execution-advice-trade-initiation.xml
@@ -12,11 +12,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="SKY"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">IRS2</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="SKY"/>
       </partyTradeIdentifier>
       <tradeDate>2007-07-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-package-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-package-price.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
         <partyReference href="sef"/>
+        <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="fcm1"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-package-spread.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/processes/msg-package-spread.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
         <partyReference href="sef"/>
+        <tradeId tradeIdScheme="http://www.sefco.com/swaps/trade-id">1</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="fcm1"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex01-gas-swap-daily-delivery-prices-last.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex01-gas-swap-daily-delivery-prices-last.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-06-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex02-gas-swap-prices-first-day.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex02-gas-swap-prices-first-day.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-06-26T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex03-gas-swap-prices-last-three-days.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex03-gas-swap-prices-last-three-days.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-08-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex04-electricity-swap-hourly-off-peak.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex04-electricity-swap-hourly-off-peak.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-07-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex05-gas-v-electricity-spark-spread.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex05-gas-v-electricity-spark-spread.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-06-11T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex06-gas-call-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex06-gas-call-option.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-05-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex07-gas-put-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex07-gas-put-option.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2007-04-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex08-oil-call-option-strip.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex08-oil-call-option-strip.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-02-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex09-oil-put-option-american.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex09-oil-put-option-american.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">163476</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">163476</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">163476</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">163476</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-10-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex27-wti-put-option-asian-listedoption-date.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex27-wti-put-option-asian-listedoption-date.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2007-04-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex28-gas-swap-daily-delivery-prices-option-last.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex28-gas-swap-daily-delivery-prices-option-last.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-06-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex39-basket-option-confirmation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex39-basket-option-confirmation.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ABCD1234</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ABCD1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">EFGH2345</tradeId>
         <partyReference href="PartyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">EFGH2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-04-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex41-oil-asian-barrier-option-strip.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex41-oil-asian-barrier-option-strip.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">UVXY54321</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">UVXY54321</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2012-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex46-simple-financial-put-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/commodity/com-ex46-simple-financial-put-option.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">GHJK0987</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">GHJK0987</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-04-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/correlation-swaps/eqcs-ex01-correlation-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/correlation-swaps/eqcs-ex01-correlation-swap.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="kom722"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
         <partyReference href="kow029"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2007-01-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/correlation-swaps/eqcs-ex02-correlation-swap-confirmation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/correlation-swaps/eqcs-ex02-correlation-swap-confirmation.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="gh4903"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="td9202">2007-05-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/correlation-swaps/eqcs-ex03-correlation-swap-confirmation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/correlation-swaps/eqcs-ex03-correlation-swap-confirmation.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="gh4903"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-11-07T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/correlation-swaps/eqcs-ex04-correlation-swap-confirmation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/correlation-swaps/eqcs-ex04-correlation-swap-confirmation.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="gh4903"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-11-07T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cd-ex01-long-asia-corp-fixreg-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cd-ex01-long-asia-corp-fixreg-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="f845ge"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">RTD3ERTF37209</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="f845ge"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cd-ex02-2003-short-asia-corp-fixreg-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cd-ex02-2003-short-asia-corp-fixreg-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="trg6836"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="trg6836"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cd-ex16-short-us-corp-fixreg-recovery-factor-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cd-ex16-short-us-corp-fixreg-recovery-factor-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="rt4563"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">IRG858TH30</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="rt4563"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cd-indamt-ex01-short-us-corp-fixreg-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cd-indamt-ex01-short-us-corp-fixreg-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="koy4rt1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="koy4rt1"/>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cdindex-ex03-iTraxx-contractual-supplement-account-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cdindex-ex03-iTraxx-contractual-supplement-account-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="g56bw4"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">ITRAXX1234</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="g56bw4"/>
       </partyTradeIdentifier>
       <tradeDate>2005-11-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cdm-cds-mortgage-CMBS-single-payment-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cdm-cds-mortgage-CMBS-single-payment-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="trg6836"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="trg6836"/>
       </partyTradeIdentifier>
       <tradeDate>2006-11-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cdm-cds-ref-ob-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cdm-cds-ref-ob-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="g4789"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="g4789"/>
       </partyTradeIdentifier>
       <tradeDate id="tradeDate">2018-10-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cds-ELCDS-ReferenceObligation-collateral-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cds-ELCDS-ReferenceObligation-collateral-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="e54t5"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="e54t5"/>
       </partyTradeIdentifier>
       <tradeDate>2007-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cds-basket-tranche-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cds-basket-tranche-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="fyure4"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="fyure4"/>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cds-index-tranche.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cds-index-tranche.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-11-03T00:00:00Z</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cds-mortgage-RMBS-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/credit/cds-mortgage-RMBS-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="yt67d"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">56ERT7RHWE4</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="yt67d"/>
       </partyTradeIdentifier>
       <tradeDate>2006-10-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex01-dividend-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex01-dividend-swap.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
         <partyReference href="kom722"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
         <partyReference href="kow029"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex02-dividend-swap-collateral.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex02-dividend-swap-collateral.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
         <partyReference href="kom722"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
         <partyReference href="kow029"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex03-dividend-swap-short-form-japanese-underlyer.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex03-dividend-swap-short-form-japanese-underlyer.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
         <partyReference href="kom722"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
         <partyReference href="kow029"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex04-dividend-swap-option-transaction-supplement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex04-dividend-swap-option-transaction-supplement.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex05-dividend-swap-option-gs-example.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex05-dividend-swap-option-gs-example.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-01-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex06-dividend-swap-option-pred-clearing.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/dividend-swaps/div-ex06-dividend-swap-option-pred-clearing.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-01-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqd-ex01-american-call-stock-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqd-ex01-american-call-stock-long-form.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqd-ex04-european-call-index-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqd-ex04-european-call-index-long-form.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-09-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex01-single-underlyer-execution-long-form-other-party.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex01-single-underlyer-execution-long-form-other-party.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex01-single-underlyer-execution-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex01-single-underlyer-execution-long-form.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex03-european-call-price-return-Index.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex03-european-call-price-return-Index.xml
@@ -11,8 +11,8 @@
         <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/unique-transaction-identifier">*NOUSIVALUE</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.dtcc.com/internal_Referenceid">55512345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.dtcc.com/internal_Referenceid">55512345</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="party1"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex06-single-index-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex06-single-index-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex09-compounding-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex09-compounding-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TRADEABC</tradeId>
         <partyReference href="BankB"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TRADEABC</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-01-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex10-short-form-interestLeg-driving-schedule-dates.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex10-short-form-interestLeg-driving-schedule-dates.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-06-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex11-on-european-single-stock-underlyer-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex11-on-european-single-stock-underlyer-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2007-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex12-on-european-index-underlyer-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex12-on-european-index-underlyer-short-form.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex13-pan-asia-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex13-pan-asia-interdealer-share-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-09-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex14-european-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/equity/eqs-ex14-european-interdealer-share-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">1558488</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">1558488</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex01-fx-spot.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex01-fx-spot.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/fx/trade-id">BARC987</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/fx/trade-id">BARC987</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-10-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex02-spot-cross-w-side-rates.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex02-spot-cross-w-side-rates.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-10-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex03-fx-fwd.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex03-fx-fwd.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex04-fx-fwd-w-settlement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex04-fx-fwd-w-settlement.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">FWD123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">FWD123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">FXD2002987</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">FXD2002987</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex05-fx-fwd-w-ssi.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex05-fx-fwd-w-ssi.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex06-fx-fwd-w-splits.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex06-fx-fwd-w-splits.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">FX048VS</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">FX048VS</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn.com/fx/trade-id">USABC023</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abn.com/fx/trade-id">USABC023</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex07-non-deliverable-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex07-non-deliverable-forward.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex08-fx-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex08-fx-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex09-euro-opt.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex09-euro-opt.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="partyX"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="partyY"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex10-amer-opt.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex10-amer-opt.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://partyA.com/trades">123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://partyA.com/trades">123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://adnamro.com/trade-ids">ABN1789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://adnamro.com/trade-ids">ABN1789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex11-non-deliverable-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex11-non-deliverable-option.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-01-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex12-fx-barrier-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex12-fx-barrier-option.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-08-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex20-avg-rate-option-parametric.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex20-avg-rate-option-parametric.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PA-12345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PA-12345</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-98765</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-98765</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-08-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex22-avg-rate-option-specific.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex22-avg-rate-option-specific.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.chase.com/fx/trade-id">CH-23948</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.chase.com/fx/trade-id">CH-23948</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-89080</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-89080</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-08-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex28-non-deliverable-w-disruption.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/fx/fx-ex28-non-deliverable-w-disruption.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="urn:hsbc:trade-id">12345678</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="urn:hsbc:trade-id">12345678</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="run:bnpp/trade-id">AZ5678901</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="run:bnpp/trade-id">AZ5678901</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-04-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/inflation-swaps/inflation-swap-ex01-yoy.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/inflation-swaps/inflation-swap-ex01-yoy.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2003-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/inflation-swaps/inflation-swap-ex02-yoy-bond-reference.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/inflation-swaps/inflation-swap-ex02-yoy-bond-reference.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2003-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/inflation-swaps/inflation-swap-ex03-yoy-initial-level.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/inflation-swaps/inflation-swap-ex03-yoy-initial-level.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2003-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/inflation-swaps/inflation-swap-ex04-yoy-interp.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/inflation-swaps/inflation-swap-ex04-yoy-interp.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2003-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/inflation-swaps/inflation-swap-ex05-zc.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/inflation-swaps/inflation-swap-ex05-zc.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-02-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/CAD-Long-Initial-Stub-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/CAD-Long-Initial-Stub-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">LCH00023323008</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>2017-12-18T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/EUR-Vanilla-extended-party-roles-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/EUR-Vanilla-extended-party-roles-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">LCH00023323008</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="party2"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/EUR-Vanilla-party-roles-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/EUR-Vanilla-party-roles-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">LCH00023323008</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>2017-12-18T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/bond-fwd-generic-ex01.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/bond-fwd-generic-ex01.xml
@@ -18,8 +18,8 @@
         <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/unique-transaction-identifier">FI-BANKXX-585125839</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.dtcc.com/internal-reference-id">FI-BANKXX-585125839</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.dtcc.com/internal-reference-id">FI-BANKXX-585125839</tradeId>
         <linkId linkIdScheme="http://www.bankx.com/trd-no">566035542</linkId>
       </partyTradeIdentifier>
       <partyTradeInformation>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/bond-fwd-generic-ex02.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/bond-fwd-generic-ex02.xml
@@ -18,8 +18,8 @@
         <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/unique-transaction-identifier">FI-BANKXX-585125839</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.dtcc.com/internal-reference-id">FI-BANKXX-585125839</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.dtcc.com/internal-reference-id">FI-BANKXX-585125839</tradeId>
         <linkId linkIdScheme="http://www.bankx.com/trd-no">566035542</linkId>
       </partyTradeIdentifier>
       <partyTradeInformation>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex01-vanilla-swap-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex01-vanilla-swap-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex02-stub-amort-swap-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex02-stub-amort-swap-versioned.xml
@@ -3,15 +3,15 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex03-compound-swap-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex03-compound-swap-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier id="tr2345">
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>2000-04-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex08-fra-no-discounting.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex08-fra-no-discounting.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hsbc.com/swaps/trade-id">MB87623</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.hsbc.com/swaps/trade-id">MB87623</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abnamro.com/swaps/trade-id">AA9876</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abnamro.com/swaps/trade-id">AA9876</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1991-05-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex08-fra.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex08-fra.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hsbc.com/swaps/trade-id">MB87623</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.hsbc.com/swaps/trade-id">MB87623</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abnamro.com/swaps/trade-id">AA9876</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abnamro.com/swaps/trade-id">AA9876</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1991-05-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex09-euro-swaption-explicit-physical-exercise.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex09-euro-swaption-explicit-physical-exercise.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex09-euro-swaption-explicit-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex09-euro-swaption-explicit-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex11-euro-swaption-partial-auto-ex.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex11-euro-swaption-partial-auto-ex.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex12-euro-swaption-straddle-cash-other-party.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex12-euro-swaption-straddle-cash-other-party.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id">FRG78TR45E</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex12-euro-swaption-straddle-cash.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex12-euro-swaption-straddle-cash.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id">FRG78TR45E</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex13-euro-swaption-cash-with-cfs.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex13-euro-swaption-cash-with-cfs.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex14-berm-swaption.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex14-berm-swaption.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex15-amer-swaption.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex15-amer-swaption.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex16-mand-term-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex16-mand-term-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex17-opt-euro-term-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex17-opt-euro-term-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex18-opt-berm-term-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex18-opt-berm-term-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex19-opt-amer-term-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex19-opt-amer-term-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex20-euro-cancel-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex20-euro-cancel-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex21-euro-extend-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex21-euro-extend-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex22-cap-with-spread.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex22-cap-with-spread.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id">FRG78TR45E</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex22-cap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex22-cap.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id">FRG78TR45E</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex23-floor-with-spread.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex23-floor-with-spread.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id">FRG78TR45E</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex23-floor.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex23-floor.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id">FRG78TR45E</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex24-collar.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex24-collar.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id">FRG78TR45E</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex26-fxnotional-swap-with-cfs.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex26-fxnotional-swap-with-cfs.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http:/www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http:/www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http:/www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http:/www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-01-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex27-inverse-floater.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex27-inverse-floater.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex28-bullet-payments.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex28-bullet-payments.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex31-non-deliverable-settlement-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex31-non-deliverable-settlement-swap.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex32-zero-coupon-swap-account-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex32-zero-coupon-swap-account-versioned.xml
@@ -3,18 +3,18 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">FRG56R1234</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>2005-02-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex33-BRL-CDI-swap-versioned.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex33-BRL-CDI-swap-versioned.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="partyA"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">987654321-0</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="partyA"/>
       </partyTradeIdentifier>
       <tradeDate>2012-06-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex34-MXN-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex34-MXN-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="buyside-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="buyside-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="sellside-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="sellside-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex35-inverse-floater-inverse-vs-floating.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex35-inverse-floater-inverse-vs-floating.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123456</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123456</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">654321</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">654321</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex36-amer-swaption-pred-clearing.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-ex36-amer-swaption-pred-clearing.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-initial-fee.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/ird-initial-fee.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/uti">IRS858TH30</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <tradeDate>2018-02-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/swap-with-other-party-payment.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/rates/swap-with-other-party-payment.xml
@@ -3,11 +3,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex01-variance-swap-index.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex01-variance-swap-index.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="d989">2001-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex02-variance-swap-single-stock.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex02-variance-swap-single-stock.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="d989">2001-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex03-conditional-variance-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex03-conditional-variance-swap.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="d989">2007-01-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex04-dispersion-variance-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex04-dispersion-variance-swap.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyz.com/coding-scheme/trade-id">280234089</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyz.com/coding-scheme/trade-id">280234089</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="td">2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex05-dispersion-variance-swap-transaction-supplement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex05-dispersion-variance-swap-transaction-supplement.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyz.com/coding-scheme/trade-id">280234089</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyz.com/coding-scheme/trade-id">280234089</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="td">2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex06-variance-option-transaction-supplement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex06-variance-option-transaction-supplement.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex07-variance-option-transaction-supplement-pred-clearing.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/variance-swaps/eqvs-ex07-variance-option-transaction-supplement-pred-clearing.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/volatility-swaps/eqvls-ex01-volatility-swap-index-matrix.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/volatility-swaps/eqvls-ex01-volatility-swap-index-matrix.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2015-03-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/volatility-swaps/eqvls-ex02-volatility-swap-index-mca.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-10/products/volatility-swaps/eqvls-ex02-volatility-swap-index-mca.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2015-03-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/incomplete-products/equity/eqs-ex04-zero-strike-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/incomplete-products/equity/eqs-ex04-zero-strike-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-10-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/processes/custom-basket-linkId-ptrr-comp.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/processes/custom-basket-linkId-ptrr-comp.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <linkId linkIdScheme="http://www.fpml.org/coding-scheme/external/esma-ptrr-compression">USDINDEX</linkId>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/processes/custom-basket-linkId-rtn.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/processes/custom-basket-linkId-rtn.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <linkId id="lid1" linkIdScheme="http://www.fpml.org/coding-scheme/external/esma-report-tracking-number">USDINDEX</linkId>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/commodity/com-ex02-energy-nat-gas-cash.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/commodity/com-ex02-energy-nat-gas-cash.xml
@@ -11,8 +11,8 @@
         <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/unique-transaction-identifier">001-229414-BR777123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.dtcc.com/internal_Referenceid">55512345</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.dtcc.com/internal_Referenceid">55512345</tradeId>
         <linkId linkIdScheme="ComposerID">ComposerID:'4307223'</linkId>
       </partyTradeIdentifier>
       <partyTradeInformation>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/commodity/com-ex1-gas-swap-daily-delivery-prices-last.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/commodity/com-ex1-gas-swap-daily-delivery-prices-last.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-06-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/commodity/com-ex5-gas-v-electricity-spark-spread.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/commodity/com-ex5-gas-v-electricity-spark-spread.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-06-11T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/commodity/com-ex8-oil-call-option-strip.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/commodity/com-ex8-oil-call-option-strip.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-02-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-ex01-long-asia-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-ex01-long-asia-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-ex02-2003-short-asia-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-ex02-2003-short-asia-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-ex16-short-us-corp-fixreg-recovery-factor.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-ex16-short-us-corp-fixreg-recovery-factor.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-indamt-ex01-short-us-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-indamt-ex01-short-us-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-swaption-1.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-swaption-1.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade123</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade123</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-12-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-swaption-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cd-swaption-2.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-06-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdindex-ex01-cdx.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdindex-ex01-cdx.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdindex-ex02-iTraxx.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdindex-ex02-iTraxx.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-11-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdindex-ex03-iTraxx-contractual-supplement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdindex-ex03-iTraxx-contractual-supplement.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">ITRAXX1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">ITRAXX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">1234B6</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">1234B6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-11-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdindex-ex04-iBoxx.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdindex-ex04-iBoxx.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdindex-ex05-SP.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdindex-ex05-SP.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-ELCDS-ReferenceObligation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-ELCDS-ReferenceObligation.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
         <partyReference href="DTCCPty1"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2007-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-basket-tranche.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-basket-tranche.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <linkId linkIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/linkID">USDINDEX</linkId>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-basket.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <linkId linkIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/linkID">USDINDEX</linkId>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-index-tranche.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-index-tranche.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-11-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-loan-ReferenceObligation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-loan-ReferenceObligation.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-10-26T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-loan-SecuredList.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-loan-SecuredList.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-12-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-mortgage-CMBS.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-mortgage-CMBS.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-11-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-mortgage-RMBS.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cds-mortgage-RMBS.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-10-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdx-index-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/cdx-index-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-01-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/itraxx-index-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/credit/itraxx-index-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-01-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqd-ex01-american-call-stock-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqd-ex01-american-call-stock-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqd-ex04-european-call-index-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqd-ex04-european-call-index-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-09-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex01-single-underlyer-execution-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex01-single-underlyer-execution-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex05-single-stock-plus-fee-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex05-single-stock-plus-fee-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1934</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1934</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5978</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5978</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-09-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex06-single-index-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex06-single-index-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex09-compounding-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex09-compounding-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TRADEABC</tradeId>
         <partyReference href="BankB"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TRADEABC</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-01-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex10-short-form-interestLeg-driving-schedule-dates.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex10-short-form-interestLeg-driving-schedule-dates.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-06-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex11-on-european-single-stock-underlyer-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex11-on-european-single-stock-underlyer-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2007-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex12-on-european-index-underlyer-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex12-on-european-index-underlyer-short-form.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex13-pan-asia-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex13-pan-asia-interdealer-share-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-09-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex14-european-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex14-european-interdealer-share-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">1558488</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">1558488</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex15-forward-starting-pre-european-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex15-forward-starting-pre-european-interdealer-share-swap-short-form.xml
@@ -12,18 +12,18 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">8848551</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>2009-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.xml
@@ -12,18 +12,18 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
           <version>2</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">8848551</tradeId>
           <version>2</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>2009-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex17-cfd.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex17-cfd.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.primarybank.com/trade-id">CFD123456789</tradeId>
         <partyReference href="PRIMARY"/>
+        <tradeId tradeIdScheme="http://www.primarybank.com/trade-id">CFD123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.crossbank.com/tradeId">CFD123456789</tradeId>
         <partyReference href="CROSS"/>
+        <tradeId tradeIdScheme="http://www.crossbank.com/tradeId">CFD123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate__CFD123456789">2009-09-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex18-pan-asia-interdealer-index-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex18-pan-asia-interdealer-index-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-09-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-09-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/trs-ex02-single-equity.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/trs-ex02-single-equity.xml
@@ -3,12 +3,12 @@
   <trade id="trs-eq1-trade">
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="trs-eq1-TradeDate">2004-10-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/trs-ex04-index-ios.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/equity/trs-ex04-index-ios.xml
@@ -3,12 +3,12 @@
   <trade id="trs-ex4-trade">
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-03-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex01-fx-spot.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex01-fx-spot.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/fx/trade-id">BARC987</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/fx/trade-id">BARC987</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-10-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex02-spot-cross-w-side-rates.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex02-spot-cross-w-side-rates.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-10-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex03-fx-fwd.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex03-fx-fwd.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex04-fx-fwd-w-settlement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex04-fx-fwd-w-settlement.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">FWD123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">FWD123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">FXD2002987</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">FXD2002987</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex05-fx-fwd-w-ssi.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex05-fx-fwd-w-ssi.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex06-fx-fwd-w-splits.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex06-fx-fwd-w-splits.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">FX048VS</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">FX048VS</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn.com/fx/trade-id">USABC023</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abn.com/fx/trade-id">USABC023</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex07-non-deliverable-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex07-non-deliverable-forward.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex08-fx-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex08-fx-swap.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex09-euro-opt.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex09-euro-opt.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex10-amer-opt.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex10-amer-opt.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://partyA.com/trades">123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://partyA.com/trades">123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://adnamro.com/trade-ids">ABN1789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://adnamro.com/trade-ids">ABN1789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex11-non-deliverable-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex11-non-deliverable-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-01-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex12-fx-barrier-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex12-fx-barrier-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-08-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex20-avg-rate-option-parametric.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex20-avg-rate-option-parametric.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PA-12345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PA-12345</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-98765</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-98765</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-08-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex22-avg-rate-option-specific.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex22-avg-rate-option-specific.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.chase.com/fx/trade-id">CH-23948</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.chase.com/fx/trade-id">CH-23948</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-89080</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-89080</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-08-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex28-non-deliverable-w-disruption.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/fx/fx-ex28-non-deliverable-w-disruption.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="urn:hsbc:trade-id">12345678</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="urn:hsbc:trade-id">12345678</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="run:bnpp/trade-id">AZ5678901</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="run:bnpp/trade-id">AZ5678901</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-04-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/bond-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/bond-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-05-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/cb-option-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/cb-option-2.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Bond1</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Bond1</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-12-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/cb-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/cb-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-01-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex01-vanilla-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex01-vanilla-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex02-stub-amort-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex02-stub-amort-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex03-compound-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex03-compound-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.msdw/swaps/trade-id">56990</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.msdw/swaps/trade-id">56990</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-04-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex04-arrears-stepup-fee-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex04-arrears-stepup-fee-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.msdw/swaps/trade-id">56990</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.msdw/swaps/trade-id">56990</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-04-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex05-long-stub-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex05-long-stub-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">921934</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">921934</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/swaps/trade-id">204334</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/swaps/trade-id">204334</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-04-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex06-xccy-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex06-xccy-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex07-ois-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex07-ois-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citibank.com/swaps/trade-id">TRN12000</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citibank.com/swaps/trade-id">TRN12000</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.mizuhocap.com/swaps/trade-id">TRN13000</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.mizuhocap.com/swaps/trade-id">TRN13000</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-01-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex08-fra.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex08-fra.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hsbc.com/swaps/trade-id">MB87623</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.hsbc.com/swaps/trade-id">MB87623</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abnamro.com/swaps/trade-id">AA9876</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abnamro.com/swaps/trade-id">AA9876</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1991-05-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex09-euro-swaption-explicit.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex09-euro-swaption-explicit.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex10-euro-swaption-relative.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex10-euro-swaption-relative.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex11-euro-swaption-partial-auto-ex.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex11-euro-swaption-partial-auto-ex.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex12-euro-swaption-straddle-cash.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex12-euro-swaption-straddle-cash.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex22-cap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex22-cap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex23-floor.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex23-floor.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex24-collar.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex24-collar.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex25-fxnotional-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex25-fxnotional-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-01-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex27-inverse-floater.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex27-inverse-floater.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex29-non-deliverable-settlement-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex29-non-deliverable-settlement-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex30-swap-comp-avg-relative-date.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex30-swap-comp-avg-relative-date.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://xml.morganstanley.com/fid/ird/msTradeIdScheme/swapName">martin</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://xml.morganstanley.com/fid/ird/msTradeIdScheme/swapName">martin</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://xml.morganstanley.com/fid/ird/counterpartyTradeIdScheme">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://xml.morganstanley.com/fid/ird/counterpartyTradeIdScheme">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="tradeDate">2005-07-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex32-zero-coupon-swap-normal-rate.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex32-zero-coupon-swap-normal-rate.xml
@@ -13,18 +13,18 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="tradeSource"/>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">1-2</tradeId>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/alpha-trade-id">11111111</tradeId>
-        <partyReference href="tradeSource"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">abc123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">abc123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="clearingDCO"/>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">LCH00000000001</tradeId>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-classification">STM</tradeId>
-        <partyReference href="clearingDCO"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
         <issuer issuerIdScheme="USINamespace">1010000051</issuer>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex33-BRL-CDI-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex33-BRL-CDI-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">987654321-0</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">987654321-0</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-06-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex40-rfr-avg-swap-obs-period-shift.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex40-rfr-avg-swap-obs-period-shift.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex46-rfr-compound-swap-lookback-oet-mmviq.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex46-rfr-compound-swap-lookback-oet-mmviq.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex47-rfr-compound-swap-lookback-oet-rvfq.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/rates/ird-ex47-rfr-compound-swap-lookback-oet-rvfq.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/repo/sbl-ex01-term-egrn-cash.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/repo/sbl-ex01-term-egrn-cash.xml
@@ -10,11 +10,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="Party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.abc.com/coding-scheme/trade-id">942800839</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="Party1"/>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="Party1"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/repo/sbl-ex02-term-fx-rate-non-cash.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-12/products/repo/sbl-ex02-term-fx-rate-non-cash.xml
@@ -10,11 +10,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="Party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.abc.com/coding-scheme/trade-id">9999999</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="Party1"/>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="Party1"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex100-execution-advice-trs-partial-termination.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex100-execution-advice-trs-partial-termination.xml
@@ -10,6 +10,7 @@
   <sequenceNumber>2</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="Originator"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">EQUITYTRSFPMLORGASSETID</tradeId>
         <version>1</version>
@@ -18,7 +19,6 @@
         <tradeId tradeIdScheme="http://www.xxx.com/coding-scheme/parent-trade-id">EQUITYTRSFPMLORGTRADEID</tradeId>
         <version>1</version>
       </versionedTradeId>
-      <partyReference href="Originator"/>
     </tradeIdentifier>
     <agreementDate>2013-04-04T00:00:00</agreementDate>
     <effectiveDate>2013-04-04T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex61-execution-advice-trade-change-F03-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex61-execution-advice-trade-change-F03-00.xml
@@ -13,11 +13,11 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR3456</tradeId>
             <version>2</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-09-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex62-execution-advice-trade-change-correction-F03-10.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex62-execution-advice-trade-change-correction-F03-10.xml
@@ -13,11 +13,11 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR3456</tradeId>
             <version>2</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-09-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex65-execution-advice-trade-partial-termination.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex65-execution-advice-trade-partial-termination.xml
@@ -12,12 +12,12 @@
   <sequenceNumber>1</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="SKY"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">IRS2</tradeId>
         <version>3</version>
         <effectiveDate>2008-07-30T00:00:00</effectiveDate>
       </versionedTradeId>
-      <partyReference href="SKY"/>
     </tradeIdentifier>
     <agreementDate>2008-07-25T00:00:00</agreementDate>
     <effectiveDate>2008-07-30T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex66-execution-advice-trade-full-termination.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex66-execution-advice-trade-full-termination.xml
@@ -12,12 +12,12 @@
   <sequenceNumber>4</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="SKY"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">IRS2</tradeId>
         <version>4</version>
         <effectiveDate>2008-07-30T00:00:00</effectiveDate>
       </versionedTradeId>
-      <partyReference href="SKY"/>
     </tradeIdentifier>
     <agreementDate>2008-07-26T00:00:00</agreementDate>
     <effectiveDate>2009-07-30T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex67-execution-advice-trade-full-termination-correction.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex67-execution-advice-trade-full-termination-correction.xml
@@ -12,12 +12,12 @@
   <sequenceNumber>5</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="SKY"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">IRS2</tradeId>
         <version>5</version>
         <effectiveDate>2008-07-30T00:00:00</effectiveDate>
       </versionedTradeId>
-      <partyReference href="SKY"/>
     </tradeIdentifier>
     <agreementDate>2008-07-26T00:00:00</agreementDate>
     <effectiveDate>2009-07-30T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex68-execution-advice-warrant.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-processes/execution-advice/msg-ex68-execution-advice-warrant.xml
@@ -9,6 +9,7 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="ABC"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.abcbank.com/coding-scheme/front-office/trade-id">1234512345</tradeId>
           <version>1</version>
@@ -17,7 +18,6 @@
           <tradeId tradeIdScheme="http://www.abcbank.com/coding-scheme/back-office/trade-id">4853560</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="ABC"/>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="ABC"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex10-physical-oil-pipeline-crude-wti-floating-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex10-physical-oil-pipeline-crude-wti-floating-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex11-physical-oil-pipeline-heating-oil-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex11-physical-oil-pipeline-heating-oil-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex12-physical-gas-europe-zbt-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex12-physical-gas-europe-zbt-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex13-physical-gas-us-tw-west-texas-pool-floating-price-4-days.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex13-physical-gas-us-tw-west-texas-pool-floating-price-4-days.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex14-physical-gas-europe-ttf-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex14-physical-gas-europe-ttf-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex15-physical-oil-pipeline-crude-wcs-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex15-physical-oil-pipeline-crude-wcs-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex16-physical-power-us-eei-floating-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex16-physical-power-us-eei-floating-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex17-physical-power-uk-gtma-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex17-physical-power-uk-gtma-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex18-physical-power-us-eei-fixed-price-shaped-volume.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex18-physical-power-us-eei-fixed-price-shaped-volume.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-04-22T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex19-physical-bullion-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex19-physical-bullion-forward.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex20-physical-coal-us-fixed-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex20-physical-coal-us-fixed-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex21-physical-power-us-eei-fixed-price-shaped-volume-and-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex21-physical-power-us-eei-fixed-price-shaped-volume-and-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-04-22T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex22-physical-gas-option-multiple-expiration.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex22-physical-gas-option-multiple-expiration.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-04-22T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex23-physical-power-option-daily-expiration-efet.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex23-physical-power-option-daily-expiration-efet.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">268151</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">268151</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">268151</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">268151</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex24-weather-index-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex24-weather-index-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-05-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex25-physical-bullion-forward-average-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex25-physical-bullion-forward-average-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.techco.com/com-trade-id">TechCo1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.techco.com/com-trade-id">TechCo1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.banka.com/com-trade-id">BankA5678</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.banka.com/com-trade-id">BankA5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-03-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex26-physical-metal-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex26-physical-metal-forward.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.BankA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.BankA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.BankB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.BankB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2013-03-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex27-wti-put-option-asian-listedoption-date.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex27-wti-put-option-asian-listedoption-date.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2007-04-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex28-gas-swap-daily-delivery-prices-option-last.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex28-gas-swap-daily-delivery-prices-option-last.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-06-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex29-physical-eu-emissions-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex29-physical-eu-emissions-option.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="tradeDate">2012-06-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex30-physical-eu-emissions-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex30-physical-eu-emissions-forward.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="tradeDate">2012-06-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex31-physical-us-emissions-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex31-physical-us-emissions-option.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="tradeDate">2012-06-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex32-CPD-weather-index-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex32-CPD-weather-index-option.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-04-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex33-physical-bullion-forward-average-price.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex33-physical-bullion-forward-average-price.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.techco.com/com-trade-id">TechCo1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.techco.com/com-trade-id">TechCo1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.banka.com/com-trade-id">BankA5678</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.banka.com/com-trade-id">BankA5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-03-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex39-basket-option-confirmation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex39-basket-option-confirmation.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ABCD1234</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ABCD1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">EFGH2345</tradeId>
         <partyReference href="PartyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">EFGH2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-04-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex40-gas-digital-option-storage-volume-trigger.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex40-gas-digital-option-storage-volume-trigger.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ABCD1234</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ABCD1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2013-05-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex42-index-return-swap-reinvestment-feature.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex42-index-return-swap-reinvestment-feature.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">SUSNUMERIS</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">SUSNUMERIS</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2014-01-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex43-WTI-variance-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex43-WTI-variance-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">T901234-123456</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">T901234-123456</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2012-05-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex44-index-return-swap-fixed-notional.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex44-index-return-swap-fixed-notional.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ACIRST1234567</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ACIRST1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2014-04-08T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex45-ag-variance-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex45-ag-variance-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ACAVS1234567</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">ACAVS1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2014-04-08T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex47-physical-eu-emissions-option-pred-clearing.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/commodity-derivatives/com-ex47-physical-eu-emissions-option-pred-clearing.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">123456</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="tradeDate">2012-06-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/correlation-swaps/eqcs-ex03-correlation-swap-confirmation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/correlation-swaps/eqcs-ex03-correlation-swap-confirmation.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="gh4903"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-11-07T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex-27-equityOptionTransactionSupplement-EMEA-interdealer.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex-27-equityOptionTransactionSupplement-EMEA-interdealer.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">2783639</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">2783639</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">2783639</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">2783639</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-02-11T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex01-american-call-stock-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex01-american-call-stock-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex04-european-call-index-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex04-european-call-index-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-09-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex05-asian-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex05-asian-long-form.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex06-averaging-in-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex06-averaging-in-long-form.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex08-basket-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex08-basket-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex09-bermuda-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex09-bermuda-long-form.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">LN 2962</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">LN 2962</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex11-quanto-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex11-quanto-long-form.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex14-american-call-stock-passthrough-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex14-american-call-stock-passthrough-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex15-basket-passthrough-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex15-basket-passthrough-long-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex16-equityOptionTransactionSupplement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex16-equityOptionTransactionSupplement.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/tradeId/OTC">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/tradeId/OTC">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2005-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex17-equityOptionTransactionSupplement-non-deliverable-share.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex17-equityOptionTransactionSupplement-non-deliverable-share.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">1</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">1</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">1</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">1</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-09-18T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex18-equityOptionTransactionSupplement-non-deliverable-index.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex18-equityOptionTransactionSupplement-non-deliverable-index.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">2</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">2</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">2</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.example.com/trade-id-1-0">2</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-02-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex19-dividend-adjustment.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex19-dividend-adjustment.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="jb2890"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2006-08-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex20-nested-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex20-nested-basket.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex21-flat-weight-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex21-flat-weight-basket.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex22-equityOptionTransactionSupplement-index-option-asian-dates.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex22-equityOptionTransactionSupplement-index-option-asian-dates.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex23-equityOptionTransactionSupplement-index-option-cliquet.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex23-equityOptionTransactionSupplement-index-option-cliquet.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex24-equityOptionTransactionSupplement-index-option-asian-schedule.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex24-equityOptionTransactionSupplement-index-option-asian-schedule.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex25-equityOptionTransactionSupplement-index-option-knock-in-knock-out-features.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-options/eqd-ex25-equityOptionTransactionSupplement-index-option-knock-in-knock-out-features.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-swaps/eqs-ex04-zero-strike-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-swaps/eqs-ex04-zero-strike-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-10-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-swaps/eqs-ex05-single-stock-plus-fee-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-swaps/eqs-ex05-single-stock-plus-fee-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1934</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1934</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5978</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5978</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-09-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-swaps/trs-ex01-equity-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/equity-swaps/trs-ex01-equity-basket.xml
@@ -3,12 +3,12 @@
   <trade id="trs-eqbasket-trade">
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-02</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-02</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-02</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-02</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="r13">2004-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/dcd-ex01-dual-currency-deposit.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/dcd-ex01-dual-currency-deposit.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.midlandnb.com/swaps/trade-id">MB87623</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.midlandnb.com/swaps/trade-id">MB87623</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn.com/swaps/trade-id">AA9876</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abn.com/swaps/trade-id">AA9876</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-06-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex04-fx-fwd-w-settlement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex04-fx-fwd-w-settlement.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">FWD123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">FWD123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">FXD2002987</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">FXD2002987</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex06-fx-fwd-w-splits.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex06-fx-fwd-w-splits.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">FX048VS</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">FX048VS</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn.com/fx/trade-id">USABC023</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abn.com/fx/trade-id">USABC023</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex12-fx-barrier-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex12-fx-barrier-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-08-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex13-fx-dbl-barrier-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex13-fx-dbl-barrier-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex14-euro-digital-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex14-euro-digital-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10014</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10014</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20014</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20014</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex15-euro-range-digital-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex15-euro-range-digital-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10015</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10015</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20015</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20015</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex16-one-touch-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex16-one-touch-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10016</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10016</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20016</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20016</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex17-no-touch-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex17-no-touch-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10017</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10017</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20018</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20018</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex18-double-one-touch-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex18-double-one-touch-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10018</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10018</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20018</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20018</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex19-double-no-touch-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex19-double-no-touch-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10019</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI10019</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20019</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/fx/trade-id">UBSW20019</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex23-straddle.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex23-straddle.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex24-delta-hedge.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex24-delta-hedge.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex25-option-strategyComponentIdentifier.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex25-option-strategyComponentIdentifier.xml
@@ -28,12 +28,12 @@
         <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/unique-transaction-identifier">01234567890123456789012345678914</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-3-0">123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex27-flexible-term-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex27-flexible-term-forward.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.bnpparibas.com/trade-id">87654321</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.bnpparibas.com/trade-id">87654321</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-09-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex32-forward-volatility-agreement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/fx-derivatives/fx-ex32-forward-volatility-agreement.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2014-09-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/repo/sbl-ex01-term-egrn-cash.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/repo/sbl-ex01-term-egrn-cash.xml
@@ -10,11 +10,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="Party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.abc.com/coding-scheme/trade-id">942800839</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="Party1"/>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="Party1"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/repo/sbl-ex02-term-fx-rate-non-cash.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/repo/sbl-ex02-term-fx-rate-non-cash.xml
@@ -10,11 +10,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="Party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.abc.com/coding-scheme/trade-id">9999999</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="Party1"/>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="Party1"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/variance-swaps/eqvs-ex01-variance-swap-index.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/variance-swaps/eqvs-ex01-variance-swap-index.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="d989">2001-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/variance-swaps/eqvs-ex03-conditional-variance-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/incomplete-products/variance-swaps/eqvs-ex03-conditional-variance-swap.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="d989">2007-01-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex51-execution-advice-trade-initiation-C01-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex51-execution-advice-trade-initiation-C01-00.xml
@@ -12,11 +12,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="_fund"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="_fund"/>
       </partyTradeIdentifier>
       <tradeDate>2009-06-08T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex52-execution-advice-trade-partial-novation-C02-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex52-execution-advice-trade-partial-novation-C02-00.xml
@@ -11,20 +11,20 @@
   <sequenceNumber>2</sequenceNumber>
   <novation>
     <newTradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>2</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </newTradeIdentifier>
     <oldTrade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
             <version>1</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-06-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.xml
@@ -11,20 +11,20 @@
   <sequenceNumber>3</sequenceNumber>
   <novation>
     <newTradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>3</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </newTradeIdentifier>
     <oldTrade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
             <version>1</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-06-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex54-execution-advice-trade-partial-termination-C11-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex54-execution-advice-trade-partial-termination-C11-00.xml
@@ -11,11 +11,11 @@
   <sequenceNumber>3</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>27</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </tradeIdentifier>
     <agreementDate>2009-07-22T00:00:00</agreementDate>
     <effectiveDate>2009-07-23T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex55-execution-advice-trade-partial-termination-cancellation-C11-10.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex55-execution-advice-trade-partial-termination-cancellation-C11-10.xml
@@ -10,11 +10,11 @@
   <sequenceNumber>4</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>27</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </tradeIdentifier>
     <agreementDate>2009-07-22T00:00:00</agreementDate>
     <effectiveDate>2009-07-23T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex56-execution-advice-trade-full-termination-C12-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex56-execution-advice-trade-full-termination-C12-00.xml
@@ -11,11 +11,11 @@
   <sequenceNumber>1</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>30</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </tradeIdentifier>
     <agreementDate>2009-07-24T00:00:00</agreementDate>
     <effectiveDate>2009-07-27T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex57-execution-advice-trade-full-termination_correction-C12-20.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex57-execution-advice-trade-full-termination_correction-C12-20.xml
@@ -11,11 +11,11 @@
   <sequenceNumber>3</sequenceNumber>
   <termination>
     <tradeIdentifier>
+      <partyReference href="_fund"/>
       <versionedTradeId>
         <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR2345</tradeId>
         <version>32</version>
       </versionedTradeId>
-      <partyReference href="_fund"/>
     </tradeIdentifier>
     <agreementDate>2009-07-24T00:00:00</agreementDate>
     <effectiveDate>2009-07-27T00:00:00</effectiveDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex58-execution-advice-trade-initiation-F01-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex58-execution-advice-trade-initiation-F01-00.xml
@@ -12,11 +12,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="_fund"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR3456</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="_fund"/>
       </partyTradeIdentifier>
       <tradeDate>2009-09-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex59-execution-advice-trade-amendment-F02-00.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex59-execution-advice-trade-amendment-F02-00.xml
@@ -13,11 +13,11 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR3456</tradeId>
             <version>2</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-09-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex60-execution-advice-trade-amendment-correction-F02-10.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex60-execution-advice-trade-amendment-correction-F02-10.xml
@@ -13,11 +13,11 @@
     <trade>
       <tradeHeader>
         <partyTradeIdentifier>
+          <partyReference href="_fund"/>
           <versionedTradeId>
             <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">CONTR3456</tradeId>
             <version>2</version>
           </versionedTradeId>
-          <partyReference href="_fund"/>
         </partyTradeIdentifier>
         <tradeDate>2009-09-08T00:00:00</tradeDate>
       </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex63-execution-advice-trade-initiation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex63-execution-advice-trade-initiation.xml
@@ -12,11 +12,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="SKY"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">IRS2</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="SKY"/>
       </partyTradeIdentifier>
       <tradeDate>2007-07-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex64-execution-advice-trade-initiation-correction.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex64-execution-advice-trade-initiation-correction.xml
@@ -12,11 +12,11 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="SKY"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.swift.com/coding-scheme/contract-id">IRS2</tradeId>
           <version>2</version>
         </versionedTradeId>
-        <partyReference href="SKY"/>
       </partyTradeIdentifier>
       <tradeDate>2007-07-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex69-commodity-swap-coal-physical-leg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex69-commodity-swap-coal-physical-leg.xml
@@ -12,13 +12,13 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <linkId linkIdScheme="http://www.fpml.org/coding-scheme/external/compression-link-identifier">0123456789</linkId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="partyA"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex69-commodity-swap-electricity-physical-leg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex69-commodity-swap-electricity-physical-leg.xml
@@ -12,13 +12,13 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <linkId linkIdScheme="http://www.fpml.org/coding-scheme/external/compression-link-identifier">0123456789</linkId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="partyA"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex69-commodity-swap-environmental-physical-leg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex69-commodity-swap-environmental-physical-leg.xml
@@ -12,13 +12,13 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <linkId linkIdScheme="http://www.fpml.org/coding-scheme/external/compression-link-identifier">0123456789</linkId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="partyA"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex69-commodity-swap-gas-physical-leg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex69-commodity-swap-gas-physical-leg.xml
@@ -12,13 +12,13 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <linkId linkIdScheme="http://www.fpml.org/coding-scheme/external/compression-link-identifier">0123456789</linkId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="partyA"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex69-execution-advice-commodity-swap-classification-new-trade-esma-emir-refit.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex69-execution-advice-commodity-swap-classification-new-trade-esma-emir-refit.xml
@@ -12,13 +12,13 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <linkId linkIdScheme="http://www.fpml.org/coding-scheme/external/compression-link-identifier">0123456789</linkId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="partyA"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex70-execution-advice-commodity-swap-classification-termination-esma-emir-refit.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/processes/execution-advice/msg-ex70-execution-advice-commodity-swap-classification-termination-esma-emir-refit.xml
@@ -13,13 +13,13 @@
     <originalTrade>
       <tradeHeader>
         <partyTradeIdentifier>
-          <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
           <partyReference href="partyA"/>
+          <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
           <linkId linkIdScheme="http://www.fpml.org/coding-scheme/external/compression-link-identifier">0123456789</linkId>
         </partyTradeIdentifier>
         <partyTradeIdentifier>
-          <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
           <partyReference href="partyB"/>
+          <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         </partyTradeIdentifier>
         <partyTradeInformation>
           <partyReference href="partyA"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/bond-options/bond-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/bond-options/bond-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-05-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/bond-options/cb-option-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/bond-options/cb-option-2.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Bond1</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Bond1</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-12-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/bond-options/cb-option-ois.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/bond-options/cb-option-ois.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2021-08-18T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/bond-options/cb-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/bond-options/cb-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-01-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex1-gas-swap-daily-delivery-prices-last.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex1-gas-swap-daily-delivery-prices-last.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-06-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex2-gas-swap-prices-first-day.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex2-gas-swap-prices-first-day.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-06-26T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex3-gas-swap-prices-last-three-days.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex3-gas-swap-prices-last-three-days.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-08-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex34-gas-put-option-european-floating-strike.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex34-gas-put-option-european-floating-strike.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyA.com/spec/2001/trade-id-1-0">COA1234567</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.companyA.com/spec/2001/trade-id-1-0">COA1234567</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyB.com/spec/2001/trade-id-1-0">COB7654321</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.companyB.com/spec/2001/trade-id-1-0">COB7654321</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-04-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex35-call-option-gas-power-heat-rate-daily.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex35-call-option-gas-power-heat-rate-daily.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyA.com/spec/2001/trade-id-1-0">163476</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.companyA.com/spec/2001/trade-id-1-0">163476</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyB.com/spec/2001/trade-id-1-0">163476</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.companyB.com/spec/2001/trade-id-1-0">163476</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-04-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex36-gas-call-option-european-spread-negative-premium-floating-strike.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex36-gas-call-option-european-spread-negative-premium-floating-strike.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyA.com/spec/2012/trade-id-1-0">COA24680</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.companyA.com/spec/2012/trade-id-1-0">COA24680</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.companyB.com/spec/2012/trade-id-1-0">COB13579</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.companyB.com/spec/2012/trade-id-1-0">COB13579</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-06-06T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex37-gold-forward-offered-rate.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex37-gold-forward-offered-rate.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.bankB.com/swaps/com-trade-id">BankA1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.bankB.com/swaps/com-trade-id">BankA1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.bankA.com/swaps/com-trade-id">BankB5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.bankA.com/swaps/com-trade-id">BankB5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-01-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex4-electricity-swap-hourly-off-peak.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex4-electricity-swap-hourly-off-peak.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-07-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex41-oil-asian-barrier-option-strip.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex41-oil-asian-barrier-option-strip.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">UVXY54321</tradeId>
         <partyReference href="PartyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">UVXY54321</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2012-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex46-simple-financial-put-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex46-simple-financial-put-option.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">GHJK0987</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">GHJK0987</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-04-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex48-gold-forward-offered-rate-ois.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex48-gold-forward-offered-rate-ois.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.bankB.com/swaps/com-trade-id">BankA1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.bankB.com/swaps/com-trade-id">BankA1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.bankA.com/swaps/com-trade-id">BankB5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.bankA.com/swaps/com-trade-id">BankB5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-18T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex5-gas-v-electricity-spark-spread.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex5-gas-v-electricity-spark-spread.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/com-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.PartyB.com/com-trade-id">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-06-11T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex6-gas-call-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex6-gas-call-option.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-05-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex7-gas-put-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex7-gas-put-option.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2007-04-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex8-oil-call-option-strip.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex8-oil-call-option-strip.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">2345</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-02-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex9-oil-put-option-american.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/commodity-derivatives/com-ex9-oil-put-option-american.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">163476</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">163476</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">163476</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">163476</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-10-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/correlation-swaps/eqcs-ex01-correlation-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/correlation-swaps/eqcs-ex01-correlation-swap.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="kom722"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
         <partyReference href="kow029"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2007-01-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/correlation-swaps/eqcs-ex02-correlation-swap-confirmation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/correlation-swaps/eqcs-ex02-correlation-swap-confirmation.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="gh4903"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="td9202">2007-05-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/correlation-swaps/eqcs-ex04-correlation-swap-confirmation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/correlation-swaps/eqcs-ex04-correlation-swap-confirmation.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="gh4903"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-11-07T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex01-long-asia-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex01-long-asia-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37209</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex02-2003-short-asia-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex02-2003-short-asia-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex02-short-asia-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex02-short-asia-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex03-long-aussie-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex03-long-aussie-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37258</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37258</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37258</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37258</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex04-short-aussie-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex04-short-aussie-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex05-long-emasia-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex05-long-emasia-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37260</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37260</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37260</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37260</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-08-22T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex06-long-emeur-sov-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex06-long-emeur-sov-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37261</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37261</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37261</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37261</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-07-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex07-2003-long-euro-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex07-2003-long-euro-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex07-long-euro-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex07-long-euro-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37262</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex08-2003-short-euro-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex08-2003-short-euro-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex08-short-euro-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex08-short-euro-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex09-long-euro-sov-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex09-long-euro-sov-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37263</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37263</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37263</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37263</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-11-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex10-2003-long-us-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex10-2003-long-us-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex10-long-us-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex10-long-us-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37264</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex11-2003-short-us-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex11-2003-short-us-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex11-short-us-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex11-short-us-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex12-long-emasia-sov-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex12-long-emasia-sov-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37205</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex13-long-asia-sov-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex13-long-asia-sov-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37206</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37206</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37206</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37206</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-11-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex14-long-emlatin-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex14-long-emlatin-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37203</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37203</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37203</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37203</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-08-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex15-long-emlatin-sov-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex15-long-emlatin-sov-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37204</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37204</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37204</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">37204</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-11-22T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex16-short-us-corp-fixreg-recovery-factor.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex16-short-us-corp-fixreg-recovery-factor.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex17-short-us-corp-portfolio-compression.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex17-short-us-corp-portfolio-compression.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex18-standard-north-american-corp.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex18-standard-north-american-corp.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-03-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex19-cdx-index-option-pred-clearing.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-ex19-cdx-index-option-pred-clearing.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-01-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-indamt-ex01-short-us-corp-fixreg.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-indamt-ex01-short-us-corp-fixreg.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyzbank.com/cd-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abcbank.com/cd-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-12-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-swaption-1.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-swaption-1.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade123</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade123</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-12-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-swaption-2.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cd-swaption-2.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-06-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex01-cdx.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex01-cdx.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex02-iTraxx.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex02-iTraxx.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-11-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex03-iTraxx-contractual-supplement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex03-iTraxx-contractual-supplement.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">ITRAXX1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">ITRAXX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">1234B6</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">1234B6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-11-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex04-iBoxx.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex04-iBoxx.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex05-SP.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex05-SP.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-01-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex06-iBoxx-ois.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdindex-ex06-iBoxx-ois.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-18T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-ELCDS-ReferenceObligation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-ELCDS-ReferenceObligation.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
         <partyReference href="DTCCPty1"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2007-10-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-basket-tranche.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-basket-tranche.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <linkId linkIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/linkID">USDINDEX</linkId>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-basket.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <linkId linkIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/linkID">USDINDEX</linkId>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-custom-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-custom-basket.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/tradeID">DJITRAXXUSDMS5Y</tradeId>
         <linkId id="lid1" linkIdScheme="http://www.barclaysglobal.com/partners/schema/v1-1/schemes/linkID">USDINDEX</linkId>
       </partyTradeIdentifier>
       <tradeDate>2004-01-24T00:00:00</tradeDate>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-index-tranche.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-index-tranche.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">ITRAXX1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234B6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2004-11-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-loan-ReferenceObligation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-loan-ReferenceObligation.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-10-26T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-loan-SecuredList.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-loan-SecuredList.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-12-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-mortgage-CMBS.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-mortgage-CMBS.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-11-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-mortgage-RMBS.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cds-mortgage-RMBS.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/">109257</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2006-10-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdx-index-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/cdx-index-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-01-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/itraxx-index-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/credit-derivatives/itraxx-index-option.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/coding-scheme/trade-id">Trade234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TRADEDATE">2006-01-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex01-dividend-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex01-dividend-swap.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
         <partyReference href="kom722"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
         <partyReference href="kow029"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex02-dividend-swap-collateral.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex02-dividend-swap-collateral.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
         <partyReference href="kom722"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
         <partyReference href="kow029"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex03-dividend-swap-short-form-japanese-underlyer.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex03-dividend-swap-short-form-japanese-underlyer.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
         <partyReference href="kom722"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
         <partyReference href="kow029"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex04-dividend-swap-option-transaction-supplement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex04-dividend-swap-option-transaction-supplement.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex05-dividend-swap-option-gs-example.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex05-dividend-swap-option-gs-example.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-01-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex06-dividend-swap-option-pred-clearing.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/dividend-swaps/div-ex06-dividend-swap-option-pred-clearing.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-01-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex02-calendar-spread-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex02-calendar-spread-short-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/tradeId/OTC">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/tradeId/OTC">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex03-call-or-put-spread-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex03-call-or-put-spread-short-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/tradeId/OTC">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/tradeId/OTC">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex07-barrier-knockout-rebate-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex07-barrier-knockout-rebate-long-form.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-07-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex10-binary-barrier-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex10-binary-barrier-long-form.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-03-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex12-vanilla-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex12-vanilla-short-form.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.PartyA.com/tradeId/OTC">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.PartyA.com/tradeId/OTC">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex13-1996-american-call-stock.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex13-1996-american-call-stock.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqd-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqd-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex26-mixed-asset-basket.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-options/eqd-ex26-mixed-asset-basket.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-07-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex01-single-underlyer-execution-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex01-single-underlyer-execution-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex02-composite-basket-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex02-composite-basket-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1245</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1245</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">4569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">4569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex03-index-quanto-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex03-index-quanto-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex06-single-index-long-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex06-single-index-long-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1734</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">5648</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex07-long-form-with-stub.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex07-long-form-with-stub.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://http://www.partyB.com/eqs-trade-id">5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://http://www.partyB.com/eqs-trade-id">5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex08-composite-basket-long-form-separate-spreads.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex08-composite-basket-long-form-separate-spreads.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1245</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">1245</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">4569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">4569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2002-07-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex09-compounding-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex09-compounding-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="TradeRefNbr">TRADEABC</tradeId>
         <partyReference href="BankB"/>
+        <tradeId tradeIdScheme="TradeRefNbr">TRADEABC</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-01-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex10-short-form-interestLeg-driving-schedule-dates.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex10-short-form-interestLeg-driving-schedule-dates.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id">124897</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2008-06-02T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex11-on-european-single-stock-underlyer-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex11-on-european-single-stock-underlyer-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2007-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex12-on-european-index-underlyer-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex12-on-european-index-underlyer-short-form.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.tradeIdScheme.com/tradeIdScheme">1147071</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex13-pan-asia-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex13-pan-asia-interdealer-share-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-09-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex14-european-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex14-european-interdealer-share-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">1558488</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">1558488</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex15-forward-starting-pre-european-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex15-forward-starting-pre-european-interdealer-share-swap-short-form.xml
@@ -12,18 +12,18 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">8848551</tradeId>
           <version>1</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>2009-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.xml
@@ -12,18 +12,18 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="party1"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyA.com/trade-id-1-0">1558488</tradeId>
           <version>2</version>
         </versionedTradeId>
-        <partyReference href="party1"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="party2"/>
         <versionedTradeId>
           <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">8848551</tradeId>
           <version>2</version>
         </versionedTradeId>
-        <partyReference href="party2"/>
       </partyTradeIdentifier>
       <tradeDate>2009-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex17-cfd.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex17-cfd.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.primarybank.com/trade-id">CFD123456789</tradeId>
         <partyReference href="PRIMARY"/>
+        <tradeId tradeIdScheme="http://www.primarybank.com/trade-id">CFD123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.crossbank.com/tradeId">CFD123456789</tradeId>
         <partyReference href="CROSS"/>
+        <tradeId tradeIdScheme="http://www.crossbank.com/tradeId">CFD123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate__CFD123456789">2009-09-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex18-pan-asia-interdealer-index-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex18-pan-asia-interdealer-index-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-09-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/tradeRefNbr">TW9236</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id-1-0">299442</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-09-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex20-single-underlyer-execution-long-form-ois.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/eqs-ex20-single-underlyer-execution-long-form-ois.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2021-08-18T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/trs-ex02-single-equity.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/trs-ex02-single-equity.xml
@@ -3,12 +3,12 @@
   <trade id="trs-eq1-trade">
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="trs-eq1-TradeDate">2004-10-10T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/eqs-trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/eqs-trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2001-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/trs-ex04-index-ios.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/trs-ex04-index-ios.xml
@@ -3,12 +3,12 @@
   <trade id="trs-ex4-trade">
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2011-03-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/trs-ex05-single-equity-with-calculation-parameters.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/equity-swaps/trs-ex05-single-equity-with-calculation-parameters.xml
@@ -3,12 +3,12 @@
   <trade id="trs-eq1-trade">
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
         <partyReference href="Party_1"/>
+        <tradeId tradeIdScheme="http://www.abc.com/swaps/trade-id">TRS-01</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
         <partyReference href="Party_2"/>
+        <tradeId tradeIdScheme="http://www.hedgeco.com/swaps/trade-id">total-ret-swap-01</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-18T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex01-fx-spot.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex01-fx-spot.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">CITI123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/fx/trade-id">BARC987</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/fx/trade-id">BARC987</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-10-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex02-spot-cross-w-side-rates.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex02-spot-cross-w-side-rates.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-10-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex03-fx-fwd.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex03-fx-fwd.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex05-fx-fwd-w-ssi.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex05-fx-fwd-w-ssi.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-11-19T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex07-non-deliverable-forward.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex07-non-deliverable-forward.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PARTYA345</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.csfb.com/fx/trade-id">CSFB9842</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex08-fx-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex08-fx-swap.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex09-euro-opt.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex09-euro-opt.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex10-amer-opt.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex10-amer-opt.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://partyA.com/trades">123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://partyA.com/trades">123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://adnamro.com/trade-ids">ABN1789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://adnamro.com/trade-ids">ABN1789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-12-04T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex11-non-deliverable-option.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex11-non-deliverable-option.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.markets.Reuters.com/rss/spec/2001/trade-id-2-0">IBFXO-0123456789</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-01-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex20-avg-rate-option-parametric.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex20-avg-rate-option-parametric.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PA-12345</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/fx/trade-id">PA-12345</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-98765</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-98765</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-08-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex21-avg-rate-option-parametric-plus-rate-observation.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex21-avg-rate-option-parametric-plus-rate-observation.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.chase.com/fx/trade-id">CH-23948</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.chase.com/fx/trade-id">CH-23948</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-89080</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-89080</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-08-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex22-avg-rate-option-specific.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex22-avg-rate-option-specific.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.chase.com/fx/trade-id">CH-23948</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.chase.com/fx/trade-id">CH-23948</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-89080</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB-89080</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-08-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex26-fxswap-multiple-USIs.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex26-fxswap-multiple-USIs.xml
@@ -20,12 +20,12 @@
         <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/unique-transaction-identifier">712345678901234567890123456789013</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">PARTYAUS33</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/swaps/trade-id">DEUTDEFF</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2002-01-23T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex28-non-deliverable-w-disruption.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex28-non-deliverable-w-disruption.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="urn:hsbc:trade-id">12345678</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="urn:hsbc:trade-id">12345678</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="run:bnpp/trade-id">AZ5678901</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="run:bnpp/trade-id">AZ5678901</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2013-04-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex30-variance-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex30-variance-swap.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2011-03-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex31-volatility-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/fx-derivatives/fx-ex31-volatility-swap.xml
@@ -10,8 +10,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.citi.com/fx/trade-id">12345</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="TradeDate">2011-03-01T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-asset-swap-ex01-ratio-zc-floored.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-asset-swap-ex01-ratio-zc-floored.xml
@@ -10,12 +10,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.party1.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.party1.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.party2.com/swaps/trade-id">1234</tradeId>
         <partyReference href="Party2"/>
+        <tradeId tradeIdScheme="http://www.party2.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-09-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-asset-swap-ex02-ratio-zc-floored.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-asset-swap-ex02-ratio-zc-floored.xml
@@ -14,12 +14,12 @@
         <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/external/unique-transaction-identifier">AA000000000000000000000088888888</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.party1.com/swaps/trade-id">88888888</tradeId>
         <partyReference href="Party1"/>
+        <tradeId tradeIdScheme="http://www.party1.com/swaps/trade-id">88888888</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.party2.com/swaps/trade-id">1234</tradeId>
         <partyReference href="Party2"/>
+        <tradeId tradeIdScheme="http://www.party2.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2014-12-05T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-asset-swap-ex03-par-par.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-asset-swap-ex03-par-par.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/trade-package-id">TR2</tradeId>
         <partyReference href="tradeSource"/>
+        <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/trade-package-id">TR2</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="counterpartyA"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-asset-swap-ex04-proceeds.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-asset-swap-ex04-proceeds.xml
@@ -12,8 +12,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/trade-package-id">TR3</tradeId>
         <partyReference href="tradeSource"/>
+        <tradeId tradeIdScheme="http://www.fpml.org/coding-scheme/trade-package-id">TR3</tradeId>
       </partyTradeIdentifier>
       <partyTradeInformation>
         <partyReference href="counterpartyA"/>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex01-yoy.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex01-yoy.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2003-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex02-yoy-bond-reference.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex02-yoy-bond-reference.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2003-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex03-yoy-initial-level.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex03-yoy-initial-level.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2003-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex04-yoy-interp.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex04-yoy-interp.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2003-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex05-zc.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex05-zc.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2005-02-20T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex06-zc.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex06-zc.xml
@@ -13,25 +13,25 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="tradeSource"/>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">1</tradeId>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/alpha-trade-id">12345678</tradeId>
-        <partyReference href="tradeSource"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">abc123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">abc123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">def456</tradeId>
         <partyReference href="clearingBroker1"/>
+        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">def456</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="clearingDCO"/>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">LCH00000000001</tradeId>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/group-id">11111111</tradeId>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/group-size">12</tradeId>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/link-id">1111111</tradeId>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-classification">STM</tradeId>
-        <partyReference href="clearingDCO"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
         <issuer issuerIdScheme="USINamespace">1010000051</issuer>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex10-float-v-float-BRL.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex10-float-v-float-BRL.xml
@@ -3,16 +3,16 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.party-a.com/swaps/trade-id">43660124A</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.party-a.com/swaps/trade-id">43660124A</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.party-b.com/swaps/trade-id">43660133A</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.party-b.com/swaps/trade-id">43660133A</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">187355008-2</tradeId>
         <partyReference href="partyC"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">187355008-2</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2022-06-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex11-CLP-fixed-v-fixed-fx-linked-notional.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex11-CLP-fixed-v-fixed-fx-linked-notional.xml
@@ -3,16 +3,16 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.party-a.com/swaps/trade-id">596604984</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.party-a.com/swaps/trade-id">596604984</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.party-b.com/swaps/trade-id">BCID71046476</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.party-b.com/swaps/trade-id">BCID71046476</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">184467696-2</tradeId>
         <partyReference href="partyC"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">184467696-2</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2022-05-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex12-CLP-fixed-v-ICP-fx-linked-notional.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/inflation-swaps/inflation-swap-ex12-CLP-fixed-v-ICP-fx-linked-notional.xml
@@ -3,16 +3,16 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.party-a.com/swaps/trade-id">596604984</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.party-a.com/swaps/trade-id">596604984</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.party-b.com/swaps/trade-id">BCID71046476</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.party-b.com/swaps/trade-id">BCID71046476</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">184467696-2</tradeId>
         <partyReference href="partyC"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">184467696-2</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2022-05-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex01-vanilla-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex01-vanilla-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex01a-vanilla-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex01a-vanilla-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-1</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-1</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-11-06T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex02-stub-amort-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex02-stub-amort-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex03-compound-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex03-compound-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.msdw/swaps/trade-id">56990</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.msdw/swaps/trade-id">56990</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-04-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex04-arrears-stepup-fee-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex04-arrears-stepup-fee-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">56323</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.msdw/swaps/trade-id">56990</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.msdw/swaps/trade-id">56990</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-04-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex04a-arrears-stepup-fee-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex04a-arrears-stepup-fee-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-4</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-4</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-11-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex05-long-stub-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex05-long-stub-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">921934</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">921934</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.ubsw.com/swaps/trade-id">204334</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.ubsw.com/swaps/trade-id">204334</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-04-03T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex05a-long-stub-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex05a-long-stub-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-5</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-5</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2019-02-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex06-xccy-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex06-xccy-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex06a-xccy-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex06a-xccy-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-6</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex07-ois-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex07-ois-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.citibank.com/swaps/trade-id">TRN12000</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.citibank.com/swaps/trade-id">TRN12000</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.mizuhocap.com/swaps/trade-id">TRN13000</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.mizuhocap.com/swaps/trade-id">TRN13000</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-01-25T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex07a-ois-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex07a-ois-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-11-15T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex07b-ois-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex07b-ois-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7b</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7b</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2023-02-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex07c-ois-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex07c-ois-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7c</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7c</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2023-02-16T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex08-fra.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex08-fra.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.hsbc.com/swaps/trade-id">MB87623</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.hsbc.com/swaps/trade-id">MB87623</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.abnamro.com/swaps/trade-id">AA9876</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.abnamro.com/swaps/trade-id">AA9876</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1991-05-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex08a-fra.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex08a-fra.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-8</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-8</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2019-01-14T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex09-euro-swaption-explicit.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex09-euro-swaption-explicit.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex09a-euro-swaption-explicit.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex09a-euro-swaption-explicit.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-9</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-9</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-09-17T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex10-euro-swaption-relative.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex10-euro-swaption-relative.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex11-euro-swaption-partial-auto-ex.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex11-euro-swaption-partial-auto-ex.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex12-euro-swaption-straddle-cash.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex12-euro-swaption-straddle-cash.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex13-euro-swaption-cash-with-cfs.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex13-euro-swaption-cash-with-cfs.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex14-berm-swaption.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex14-berm-swaption.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex15-amer-swaption.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex15-amer-swaption.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex16-mand-term-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex16-mand-term-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex17-opt-euro-term-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex17-opt-euro-term-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex18-opt-berm-term-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex18-opt-berm-term-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex19-opt-amer-term-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex19-opt-amer-term-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex20-euro-cancel-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex20-euro-cancel-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex21-euro-extend-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex21-euro-extend-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex22-cap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex22-cap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex23-floor.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex23-floor.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex24-collar.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex24-collar.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex25-fxnotional-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex25-fxnotional-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-01-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex26-fxnotional-swap-with-cfs.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex26-fxnotional-swap-with-cfs.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http:/www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http:/www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http:/www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http:/www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-01-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex27-inverse-floater.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex27-inverse-floater.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex28-bullet-payments.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex28-bullet-payments.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2001-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex29-non-deliverable-settlement-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex29-non-deliverable-settlement-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex30-swap-comp-avg-relative-date.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex30-swap-comp-avg-relative-date.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://xml.morganstanley.com/fid/ird/msTradeIdScheme/swapName">martin</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://xml.morganstanley.com/fid/ird/msTradeIdScheme/swapName">martin</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://xml.morganstanley.com/fid/ird/counterpartyTradeIdScheme">1234567</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://xml.morganstanley.com/fid/ird/counterpartyTradeIdScheme">1234567</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="tradeDate">2005-07-31T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex31-non-deliverable-settlement-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex31-non-deliverable-settlement-swap.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">E2000098N10184</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>1994-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex32-zero-coupon-swap-normal-rate.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex32-zero-coupon-swap-normal-rate.xml
@@ -13,18 +13,18 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="tradeSource"/>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">1-2</tradeId>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/alpha-trade-id">11111111</tradeId>
-        <partyReference href="tradeSource"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">abc123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">abc123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="clearingDCO"/>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">LCH00000000001</tradeId>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-classification">STM</tradeId>
-        <partyReference href="clearingDCO"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
         <issuer issuerIdScheme="USINamespace">1010000051</issuer>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex33-BRL-CDI-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex33-BRL-CDI-swap.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">987654321-0</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">987654321-0</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2012-06-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex34-MXN-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex34-MXN-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="buyside-trade-id">xyz1234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="buyside-trade-id">xyz1234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="sellside-trade-id">abc1234</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="sellside-trade-id">abc1234</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2010-12-12T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex35-inverse-floater-inverse-vs-floating.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex35-inverse-floater-inverse-vs-floating.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123456</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123456</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">654321</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">654321</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-04-29T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex36-amer-swaption-pred-clearing.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex36-amer-swaption-pred-clearing.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">123</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2000-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex37-zero-coupon-swap-known-amount-schedule.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex37-zero-coupon-swap-known-amount-schedule.xml
@@ -13,22 +13,22 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
+        <partyReference href="tradeSource"/>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">1-2</tradeId>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/alpha-trade-id">11111111</tradeId>
-        <partyReference href="tradeSource"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">abc123</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">abc123</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">def456</tradeId>
         <partyReference href="clearingBroker1"/>
+        <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">def456</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
+        <partyReference href="clearingDCO"/>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-id">LCH00000000001</tradeId>
         <tradeId tradeIdScheme="http://www.lchclearnet.com/clearlink/coding-scheme/trade-classification">STM</tradeId>
-        <partyReference href="clearingDCO"/>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
         <issuer issuerIdScheme="USINamespace">1010000051</issuer>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex38-rfr-avg-swap-pmt-delay.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex38-rfr-avg-swap-pmt-delay.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex39-rfr-avg-swap-rate-cutoff.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex39-rfr-avg-swap-rate-cutoff.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex40-rfr-avg-swap-obs-period-shift.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex40-rfr-avg-swap-obs-period-shift.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex41-rfr-avg-swap-lookback.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex41-rfr-avg-swap-lookback.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex42-rfr-compound-swap-pmt-delay.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex42-rfr-compound-swap-pmt-delay.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex43-rfr-compound-swap-rate-cutoff.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex43-rfr-compound-swap-rate-cutoff.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex44-rfr-compound-swap-obs-period-shift.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex44-rfr-compound-swap-obs-period-shift.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex45-rfr-compound-swap-lookback.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex45-rfr-compound-swap-lookback.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex46-rfr-compound-swap-lookback-oet-mmviq.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex46-rfr-compound-swap-lookback-oet-mmviq.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex47-rfr-compound-swap-lookback-oet-rvfq.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex47-rfr-compound-swap-lookback-oet-rvfq.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex48-rfr-compound-swap-lookback-oet-ccp.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex48-rfr-compound-swap-lookback-oet-ccp.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex49-rfr-euro-swaption-cash.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex49-rfr-euro-swaption-cash.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">62547265</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">62547265</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">62547265</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">62547265</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex50-rfr-euro-swaption-cleared-physical_with_met.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex50-rfr-euro-swaption-cleared-physical_with_met.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">62546871</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">62546871</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">62546871</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">62546871</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex51-vanilla-swap-with-fallback.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex51-vanilla-swap-with-fallback.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-1</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-1</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-06T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex52-xccy-swap-fallback.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex52-xccy-swap-fallback.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-6</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex53-xccy-swap-OIS.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex53-xccy-swap-OIS.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-6</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex54-CP-H.15-basis-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex54-CP-H.15-basis-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005713</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005713</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005713</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005713</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-04-07T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex55-muni-basis-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex55-muni-basis-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005869</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005869</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005869</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005869</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-04-07T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex56-CNREPOFIX-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex56-CNREPOFIX-swap.xml
@@ -3,12 +3,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005778</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005778</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005778</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">58005778</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-04-07T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex57-compound-index-obs-period-shift.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex57-compound-index-obs-period-shift.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-7</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2021-08-13T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex58-xccy-swap-lookback_compound.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/interest-rate-derivatives/ird-ex58-xccy-swap-lookback_compound.xml
@@ -3,8 +3,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-6</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">FpML-test-6</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2018-09-09T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/variance-swaps/eqvs-ex02-variance-swap-single-stock.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/variance-swaps/eqvs-ex02-variance-swap-single-stock.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.partyA.com/coding-scheme/trade-id">6234</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.partyB.com/coding-scheme/trade-id">6569</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="d989">2001-09-24T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/variance-swaps/eqvs-ex04-dispersion-variance-swap.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/variance-swaps/eqvs-ex04-dispersion-variance-swap.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyz.com/coding-scheme/trade-id">280234089</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyz.com/coding-scheme/trade-id">280234089</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="td">2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/variance-swaps/eqvs-ex05-dispersion-variance-swap-transaction-supplement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/variance-swaps/eqvs-ex05-dispersion-variance-swap-transaction-supplement.xml
@@ -11,8 +11,8 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.xyz.com/coding-scheme/trade-id">280234089</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.xyz.com/coding-scheme/trade-id">280234089</tradeId>
       </partyTradeIdentifier>
       <tradeDate id="td">2000-06-28T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/variance-swaps/eqvs-ex06-variance-option-transaction-supplement.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/variance-swaps/eqvs-ex06-variance-option-transaction-supplement.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/variance-swaps/eqvs-ex07-variance-option-transaction-supplement-pred-clearing.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/variance-swaps/eqvs-ex07-variance-option-transaction-supplement-pred-clearing.xml
@@ -12,12 +12,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyA"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
         <partyReference href="partyB"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">166555</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2009-01-27T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/volatility-swaps/eqvls-ex01-volatility-swap-index-matrix.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/volatility-swaps/eqvls-ex01-volatility-swap-index-matrix.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2015-03-30T00:00:00</tradeDate>
     </tradeHeader>

--- a/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/volatility-swaps/eqvls-ex02-volatility-swap-index-mca.xml
+++ b/tests/src/test/resources/serialisation/output/xml/fpml-5-13/products/volatility-swaps/eqvls-ex02-volatility-swap-index-mca.xml
@@ -11,12 +11,12 @@
   <trade>
     <tradeHeader>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
         <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
       </partyTradeIdentifier>
       <partyTradeIdentifier>
-        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
         <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.swapswire.com/spec/2001/trade-id-1-0">6403855</tradeId>
       </partyTradeIdentifier>
       <tradeDate>2015-03-30T00:00:00</tradeDate>
     </tradeHeader>


### PR DESCRIPTION
Migrates the model to the newer DSL setup, mirroring the recent upgrade of the demo project. Updated to the latest **complete** 10.x/12.x bundle pair.

## Version selection

- **DSL 10.2.3 / bundle 12.3.3** — the latest matched pair where the full bundle (both `rune-common` and `rune-testing`) is published. Note: `rune-common 12.4.0` / DSL 10.3.0 exist, but there is no `rune-testing 12.4.0` yet, so that bundle is not usable by a model project.

## Changes (3 commits)

1. **Update to rune-dsl 10.2.3 / bundle 12.3.3 and add rune-config** — version bump; new read-only `rune-config.yml`; wired `runeConfig`; added `verify-readonly-namespaces` workflow.
2. **Re-import the FpML model with rune-dsl 10.2.3** — `consolidated-desc.rosetta` declares the schemas as `schema … XML [externalConfig]`; `^definition` unescaped.
3. **Update serialisation expectations** — 754 XML round-trip expectations regenerated (schema-declaration element order: `partyReference` before the trade-id choice, matching the FpML XSD).

## Verification

`mvn clean install` passes: **817/817** serialisation round-trip tests green.