### PR TITLE
[2.x.x] Fix CVE scanning failures: jackson-databind bump, Eclipse Platform FP

### DIFF
--- a/allow-list.xml
+++ b/allow-list.xml
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <!-- False positive: CVE-2020-27225 is missing authentication on the Eclipse
+    Platform Help Subsystem's local livehelp web server (org.eclipse.help.*),
+    not the core.*/equinox.* OSGi runtime bundles pulled in here transitively
+    (via rune-testing -> org.eclipse.xtext.xbase.testing, test scope only).
+    dependency-check's CPE matching for cpe:2.3:a:eclipse:platform:* is
+    overly broad and flags any org.eclipse.platform artifact regardless of
+    which bundle actually contains the vulnerable code - see
+    https://github.com/dependency-check/DependencyCheck/issues/7663 and
+    https://github.com/jeremylong/DependencyCheck/issues/5882 for the same
+    false positive reported against other org.eclipse.platform bundles. -->
+    <suppress>
+        <notes><![CDATA[
+        False positive - see comment above.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.platform/.*$</packageUrl>
+        <cve>CVE-2020-27225</cve>
+    </suppress>
     <!--
     This is an empty suppression file for the dependency-check/Dependency-Check_Action@main GitHub Action.
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,8 @@
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>
         <guava.version>33.3.1-jre</guava.version>
-        <jackson.version>2.18.0</jackson.version>
+        <!-- Pinned past 2.18.0 to fix CVE-2026-54512 / CVE-2026-54513 -->
+        <jackson.version>2.22.1</jackson.version>
 
         <!-- Release -->
         <gpg.keyname>configured-by-release-profile</gpg.keyname>


### PR DESCRIPTION
## Summary
- `jackson-databind` 2.18.0 -> 2.22.1 (via the existing `jackson.version` property/BOM import): fixes CVE-2026-54512 / CVE-2026-54513. Pulled in transitively via `rosetta-common`.
- Suppresses CVE-2020-27225 for `org.eclipse.platform:*` artifacts. Verified this is a known dependency-check false positive: the CVE is an authentication gap in the Help Subsystem's local livehelp web server (`org.eclipse.help.*`), not the `org.eclipse.core.*`/`org.eclipse.equinox.*` OSGi runtime bundles actually pulled in here (transitively, test scope, via `rune-testing` -> `org.eclipse.xtext.xbase.testing`). Confirmed the same false positive has been reported against other `org.eclipse.platform` artifacts: [dependency-check/DependencyCheck#7663](https://github.com/dependency-check/DependencyCheck/issues/7663), [jeremylong/DependencyCheck#5882](https://github.com/jeremylong/DependencyCheck/issues/5882).

Confirmed locally: `mvn clean install` still succeeds, and `dependency:tree` shows `jackson-databind` now resolves to 2.22.1.

## Test plan
- [ ] Confirm `cve-scanning.yml` passes on this branch