### PR TITLE
[2.x.x] Update  DSL to 9.92.1 and bundle to 11.132.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.enforced.version>[21,22)</java.enforced.version>
         <maven.compiler.release>11</maven.compiler.release>
-        <rosetta.dsl.version>9.89.0</rosetta.dsl.version>
-        <rosetta.bundle.version>11.129.0</rosetta.bundle.version>
+        <rosetta.dsl.version>9.92.1</rosetta.dsl.version>
+        <rosetta.bundle.version>11.132.0</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Bumps `rosetta.dsl.version` to `9.92.1` and `rosetta.bundle.version` to `11.132.0` in `pom.xml`.